### PR TITLE
feat: Implement SQLMap and Ghauri scanners in SQLi module

### DIFF
--- a/cyberhunter_3d/core/vulnerability/scanners/sqli_scanner.py
+++ b/cyberhunter_3d/core/vulnerability/scanners/sqli_scanner.py
@@ -3,17 +3,90 @@ from ...plugins.context import ScanContext
 
 log = logging.getLogger(__name__)
 
-def run_sqlmap(context: ScanContext):
-    """Runs SQLMap scanner."""
-    log.info("Running SQLMap scanner (placeholder).")
-    # Placeholder for actual implementation
-    return []
+import os
+import tempfile
+from ..utils import run_command
 
-def run_ghauri(context: ScanContext):
-    """Runs Ghauri scanner."""
-    log.info("Running Ghauri scanner (placeholder).")
-    # Placeholder for actual implementation
-    return []
+def run_sqlmap(context: ScanContext) -> list:
+    """
+    Runs SQLMap scanner on parameterized URLs.
+    """
+    log.info("Running SQLMap scanner...")
+    param_urls = context.get("parameterized_urls", [])
+    if not param_urls:
+        log.info("No parameterized URLs found for SQLMap scan.")
+        return []
+
+    config = context.get("config", {})
+    sqlmap_command_template = config.get("tool_commands", {}).get("sqlmap_scan")
+    if not sqlmap_command_template:
+        log.error("SQLMap command template not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(param_urls))
+        input_filepath = urls_file.name
+
+    sqlmap_output_dir = os.path.join(context.results_dir, "sqlmap_results")
+    os.makedirs(sqlmap_output_dir, exist_ok=True)
+
+    command = sqlmap_command_template.format(
+        input_file=input_filepath,
+        output_dir=sqlmap_output_dir
+    )
+
+    stdout, stderr = run_command(command, "SQLMap")
+    os.remove(input_filepath)
+
+    # Parsing SQLMap's output is complex. For now, we'll check if the output
+    # directory contains any results, which indicates a potential vulnerability.
+    vulnerabilities = []
+    if os.path.exists(sqlmap_output_dir) and os.listdir(sqlmap_output_dir):
+        log.info(f"SQLMap found potential vulnerabilities. Results are in: {sqlmap_output_dir}")
+        vulnerabilities.append(f"SQLMap found potential vulnerabilities. Check the results in {sqlmap_output_dir}")
+
+    log.info("SQLMap scan completed.")
+    return vulnerabilities
+
+def run_ghauri(context: ScanContext) -> list:
+    """
+    Runs Ghauri scanner on parameterized URLs.
+    """
+    log.info("Running Ghauri scanner...")
+    param_urls = context.get("parameterized_urls", [])
+    if not param_urls:
+        log.info("No parameterized URLs found for Ghauri scan.")
+        return []
+
+    config = context.get("config", {})
+    ghauri_command_template = config.get("tool_commands", {}).get("ghauri_scan")
+    if not ghauri_command_template:
+        log.error("Ghauri command template not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(param_urls))
+        input_filepath = urls_file.name
+
+    output_filepath = os.path.join(context.results_dir, "ghauri_results.txt")
+
+    command = ghauri_command_template.format(
+        input_file=input_filepath,
+        output_file=output_filepath
+    )
+
+    stdout, stderr = run_command(command, "Ghauri")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if os.path.exists(output_filepath):
+        with open(output_filepath, 'r') as f:
+            for line in f:
+                if line.strip():
+                    vulnerabilities.append(line.strip())
+
+    log.info(f"Ghauri scan completed. Found {len(vulnerabilities)} potential vulnerabilities.")
+    return vulnerabilities
 
 def run_custom_payloads(context: ScanContext):
     """Runs custom SQLi payloads."""


### PR DESCRIPTION
This commit implements the SQLMap and Ghauri scanners within the new parallel scanning engine's SQLi module.

Key changes:
- The `run_sqlmap` function in `sqli_scanner.py` now executes sqlmap and logs the output directory for further analysis.
- The `run_ghauri` function in `sqli_scanner.py` now executes the ghauri tool and parses its text output for vulnerabilities.
- The `run_custom_payloads` function remains as a placeholder for future implementation.