### PR TITLE
feat: Implement LFI scanning module

### DIFF
--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -98,7 +98,7 @@ tool_commands:
   ghauri_scan: "ghauri -l {input_file} --batch -o {output_file}"
 
   # LFI Testing
-  # Often done with custom scripts or nuclei templates. No single tool command.
+  nuclei_lfi_scan: "nuclei -l {input_file} -t lfi/ -json -o {output_file} -silent"
 
   # CORS Scanning
   corscanner_scan: "python3 CORScanner/cors_scan.py -i {input_file} -o {output_file}"

--- a/cyberhunter_3d/core/vulnerability/scanners/lfi_scanner.py
+++ b/cyberhunter_3d/core/vulnerability/scanners/lfi_scanner.py
@@ -3,22 +3,75 @@ from ...plugins.context import ScanContext
 
 log = logging.getLogger(__name__)
 
-def test_path_traversal(context: ScanContext):
-    """Tests for Path Traversal vulnerabilities."""
-    log.info("Testing for Path Traversal (placeholder).")
-    # Placeholder for actual implementation
+import os
+import tempfile
+import json
+from ..utils import run_command
+
+def test_path_traversal(context: ScanContext) -> list:
+    """
+    Tests for Path Traversal vulnerabilities using Nuclei.
+    """
+    log.info("Testing for Path Traversal vulnerabilities...")
+    # This test is suitable for any live URL, not just parameterized ones.
+    live_urls = context.get("live_urls_2xx", [])
+    if not live_urls:
+        log.info("No live URLs found for Path Traversal scan.")
+        return []
+
+    config = context.get("config", {})
+    nuclei_command_template = config.get("tool_commands", {}).get("nuclei_lfi_scan")
+    if not nuclei_command_template:
+        log.error("Nuclei LFI scan command template not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(live_urls))
+        input_filepath = urls_file.name
+
+    output_filepath = os.path.join(context.results_dir, "nuclei_lfi_results.json")
+
+    command = nuclei_command_template.format(
+        input_file=input_filepath,
+        output_file=output_filepath
+    )
+
+    stdout, stderr = run_command(command, "Nuclei (LFI)")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if os.path.exists(output_filepath):
+        with open(output_filepath, 'r') as f:
+            for line in f:
+                try:
+                    vulnerabilities.append(json.loads(line))
+                except json.JSONDecodeError:
+                    log.warning(f"Could not parse Nuclei output line: {line}")
+
+    log.info(f"Path Traversal scan completed. Found {len(vulnerabilities)} potential vulnerabilities.")
+    return vulnerabilities
+
+def test_wrapper_fuzzing(context: ScanContext) -> list:
+    """
+    Tests for LFI using wrapper fuzzing. This is often covered by the same
+    Nuclei templates used for path traversal, so this function can be a placeholder
+    or call the same logic. For simplicity, we'll note that path traversal templates
+    should cover this.
+    """
+    log.info("Wrapper fuzzing for LFI is assumed to be covered by the main path traversal scan.")
     return []
 
-def test_wrapper_fuzzing(context: ScanContext):
-    """Tests for LFI using wrapper fuzzing."""
-    log.info("Testing LFI with wrapper fuzzing (placeholder).")
-    # Placeholder for actual implementation
-    return []
-
-def test_log_poisoning(context: ScanContext):
-    """Tests for LFI via log poisoning."""
-    log.info("Testing LFI with log poisoning (placeholder).")
-    # Placeholder for actual implementation
+def test_log_poisoning(context: ScanContext) -> list:
+    """
+    Tests for LFI via log poisoning. This is a placeholder for a more complex
+    multi-step process.
+    """
+    log.info("Testing for LFI via log poisoning (placeholder).")
+    # A full implementation would involve:
+    # 1. Sending a request with a malicious payload (e.g., <?php system($_GET['cmd']); ?>) to the server.
+    # 2. Hoping this payload gets written to a log file (e.g., /var/log/apache2/access.log).
+    # 3. Trying to include that log file via a found LFI vulnerability.
+    # This is difficult to automate reliably without a high risk of false positives/negatives.
     return []
 
 def run_lfi_tests(context: ScanContext):


### PR DESCRIPTION
This commit implements the LFI (Local File Inclusion) testing module.

Key changes:
- Added a `nuclei_lfi_scan` command to the configuration for running LFI-specific Nuclei templates.
- The `test_path_traversal` function in `lfi_scanner.py` now uses Nuclei to scan for LFI vulnerabilities.
- `test_wrapper_fuzzing` and `test_log_poisoning` are included as placeholders with comments explaining that the main LFI scan should cover wrapper fuzzing and that log poisoning is too complex for simple automation.