### PR TITLE
feat: Implement CORS scanning module

### DIFF
--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -102,6 +102,7 @@ tool_commands:
 
   # CORS Scanning
   corscanner_scan: "python3 CORScanner/cors_scan.py -i {input_file} -o {output_file}"
+   nuclei_cors_scan: "nuclei -l {input_file} -t misconfiguration/cors/ -json -o {output_file} -silent"
 
   # Sensitive Data
   git_exposure_check: "httpx -l {input_file} -path /.git/config -status-code -mc 200"

--- a/cyberhunter_3d/core/vulnerability/scanners/cors_scanner.py
+++ b/cyberhunter_3d/core/vulnerability/scanners/cors_scanner.py
@@ -3,23 +3,108 @@ from ...plugins.context import ScanContext
 
 log = logging.getLogger(__name__)
 
-def run_corscanner(context: ScanContext):
-    """Runs CORScanner."""
-    log.info("Running CORScanner (placeholder).")
-    # Placeholder for actual implementation
+import os
+import tempfile
+import json
+from ..utils import run_command
+
+def run_corscanner(context: ScanContext) -> list:
+    """
+    Runs CORScanner on live URLs.
+    """
+    log.info("Running CORScanner...")
+    live_urls = context.get("live_urls_2xx", [])
+    if not live_urls:
+        log.info("No live URLs found for CORScanner scan.")
+        return []
+
+    config = context.get("config", {})
+    cors_command_template = config.get("tool_commands", {}).get("corscanner_scan")
+    if not cors_command_template:
+        log.error("CORScanner command template not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(live_urls))
+        input_filepath = urls_file.name
+
+    output_filepath = os.path.join(context.results_dir, "corscanner_results.json")
+
+    command = cors_command_template.format(
+        input_file=input_filepath,
+        output_file=output_filepath
+    )
+
+    stdout, stderr = run_command(command, "CORScanner")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if os.path.exists(output_filepath):
+        try:
+            with open(output_filepath, 'r') as f:
+                results = json.load(f)
+                # Assuming the output is a list of vulnerability objects
+                if isinstance(results, list):
+                    vulnerabilities.extend(results)
+        except (json.JSONDecodeError, TypeError):
+            log.warning(f"Could not parse CORScanner output file: {output_filepath}. Reading as text.")
+            with open(output_filepath, 'r') as f:
+                for line in f:
+                    if line.strip():
+                        vulnerabilities.append(line.strip())
+
+    log.info(f"CORScanner scan completed. Found {len(vulnerabilities)} potential vulnerabilities.")
+    return vulnerabilities
+
+def test_origin_reflection(context: ScanContext) -> list:
+    """
+    Tests for misconfigured CORS by reflecting the Origin header.
+    This is assumed to be covered by CORScanner.
+    """
+    log.info("Origin reflection testing is assumed to be covered by CORScanner.")
     return []
 
-def test_origin_reflection(context: ScanContext):
-    """Tests for misconfigured CORS by reflecting the Origin header."""
-    log.info("Testing for permissive Origin reflection (placeholder).")
-    # Placeholder for actual implementation
-    return []
+def run_nuclei_cors_templates(context: ScanContext) -> list:
+    """
+    Runs Nuclei templates specific to CORS misconfigurations.
+    """
+    log.info("Running Nuclei CORS templates...")
+    live_urls = context.get("live_urls_2xx", [])
+    if not live_urls:
+        log.info("No live URLs found for Nuclei CORS scan.")
+        return []
 
-def run_nuclei_cors_templates(context: ScanContext):
-    """Runs Nuclei templates specific to CORS misconfigurations."""
-    log.info("Running Nuclei CORS templates (placeholder).")
-    # Placeholder for actual implementation
-    return []
+    config = context.get("config", {})
+    nuclei_command_template = config.get("tool_commands", {}).get("nuclei_cors_scan")
+    if not nuclei_command_template:
+        log.error("Nuclei CORS scan command template not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(live_urls))
+        input_filepath = urls_file.name
+
+    output_filepath = os.path.join(context.results_dir, "nuclei_cors_results.json")
+
+    command = nuclei_command_template.format(
+        input_file=input_filepath,
+        output_file=output_filepath
+    )
+
+    stdout, stderr = run_command(command, "Nuclei (CORS)")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if os.path.exists(output_filepath):
+        with open(output_filepath, 'r') as f:
+            for line in f:
+                try:
+                    vulnerabilities.append(json.loads(line))
+                except json.JSONDecodeError:
+                    log.warning(f"Could not parse Nuclei output line: {line}")
+
+    log.info(f"Nuclei CORS scan completed. Found {len(vulnerabilities)} potential vulnerabilities.")
+    return vulnerabilities
 
 def run_cors_scans(context: ScanContext):
     """


### PR DESCRIPTION
This commit implements the CORS (Cross-Origin Resource Sharing) scanning module.

Key changes:
- Added a `nuclei_cors_scan` command to the configuration for running CORS-specific Nuclei templates.
- The `run_corscanner` function in `cors_scanner.py` now executes the CORScanner tool.
- The `run_nuclei_cors_templates` function now uses Nuclei to scan for common CORS misconfigurations.
- `test_origin_reflection` is included as a placeholder, as this technique is covered by the other tools.