### PR TITLE
feat: Implement Sensitive Data Exposure scanning module

### DIFF
--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -106,8 +106,9 @@ tool_commands:
 
   # Sensitive Data
   git_exposure_check: "httpx -l {input_file} -path /.git/config -status-code -mc 200"
-  backup_file_check: "nuclei -l {input_file} -t exposures/backups/ -o {output_file}"
-  config_file_check: "nuclei -l {input_file} -t exposures/configs/ -o {output_file}"
+   api_keys_check: "nuclei -l {input_file} -t exposures/api-keys/ -json -o {output_file} -silent"
+   backup_file_check: "nuclei -l {input_file} -t exposures/backups/ -json -o {output_file} -silent"
+   config_file_check: "nuclei -l {input_file} -t exposures/configs/ -json -o {output_file} -silent"
 
   # SSRF/XXE
   ssrf_callback_test: "nuclei -l {input_file} -t ssrf/ -o {output_file}" # Assumes interactsh server is configured

--- a/cyberhunter_3d/core/vulnerability/scanners/sensitive_data_scanner.py
+++ b/cyberhunter_3d/core/vulnerability/scanners/sensitive_data_scanner.py
@@ -3,29 +3,115 @@ from ...plugins.context import ScanContext
 
 log = logging.getLogger(__name__)
 
-def check_git_exposure(context: ScanContext):
-    """Checks for exposed .git directories."""
-    log.info("Checking for .git exposure (placeholder).")
-    # Placeholder for actual implementation
-    return []
+import os
+import tempfile
+import json
+from ..utils import run_command
 
-def find_api_keys(context: ScanContext):
-    """Scans for exposed API keys in code and configs."""
-    log.info("Scanning for API keys (placeholder).")
-    # Placeholder for actual implementation
-    return []
+def check_git_exposure(context: ScanContext) -> list:
+    """
+    Checks for exposed .git directories using httpx.
+    """
+    log.info("Checking for .git exposure...")
+    live_urls = context.get("live_urls_2xx", [])
+    if not live_urls:
+        log.info("No live URLs found for .git exposure check.")
+        return []
 
-def find_backup_files(context: ScanContext):
-    """Looks for common backup file extensions."""
-    log.info("Searching for backup files (placeholder).")
-    # Placeholder for actual implementation
-    return []
+    config = context.get("config", {})
+    git_check_command_template = config.get("tool_commands", {}).get("git_exposure_check")
+    if not git_check_command_template:
+        log.error("Git exposure check command template not found in config.")
+        return []
 
-def find_config_files(context: ScanContext):
-    """Looks for exposed configuration files."""
-    log.info("Searching for config files (placeholder).")
-    # Placeholder for actual implementation
-    return []
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        # We need the base URLs, not URLs with paths
+        base_urls = {f"{url.scheme}://{url.netloc}" for url in map(lambda u: __import__('urllib.parse').urlparse(u), live_urls)}
+        urls_file.write("\n".join(base_urls))
+        input_filepath = urls_file.name
+
+    command = git_check_command_template.format(input_file=input_filepath)
+
+    stdout, stderr = run_command(command, "httpx (git check)")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if stdout:
+        # httpx with -mc 200 will only print the URLs that returned a 200 status code
+        found_urls = stdout.strip().split('\n')
+        for url in found_urls:
+            if url.strip():
+                vulnerabilities.append(f"Potential .git directory exposure found at: {url.strip()}")
+
+    log.info(f".git exposure check completed. Found {len(vulnerabilities)} potential issues.")
+    return vulnerabilities
+
+def _run_nuclei_template_scan(context: ScanContext, template_key: str, output_filename: str, log_message: str) -> list:
+    """Helper function to run a Nuclei scan with a specific template key."""
+    log.info(log_message)
+    live_urls = context.get("live_urls_2xx", [])
+    if not live_urls:
+        log.info(f"No live URLs found for {template_key} scan.")
+        return []
+
+    config = context.get("config", {})
+    nuclei_command_template = config.get("tool_commands", {}).get(template_key)
+    if not nuclei_command_template:
+        log.error(f"Nuclei template for '{template_key}' not found in config.")
+        return []
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".txt") as urls_file:
+        urls_file.write("\n".join(live_urls))
+        input_filepath = urls_file.name
+
+    output_filepath = os.path.join(context.results_dir, output_filename)
+
+    command = nuclei_command_template.format(
+        input_file=input_filepath,
+        output_file=output_filepath
+    )
+
+    stdout, stderr = run_command(command, f"Nuclei ({template_key})")
+    os.remove(input_filepath)
+
+    vulnerabilities = []
+    if os.path.exists(output_filepath):
+        with open(output_filepath, 'r') as f:
+            for line in f:
+                try:
+                    vulnerabilities.append(json.loads(line))
+                except json.JSONDecodeError:
+                    log.warning(f"Could not parse Nuclei output line: {line}")
+
+    log.info(f"Scan for '{template_key}' completed. Found {len(vulnerabilities)} potential issues.")
+    return vulnerabilities
+
+def find_api_keys(context: ScanContext) -> list:
+    """Scans for exposed API keys using Nuclei."""
+    return _run_nuclei_template_scan(
+        context,
+        "api_keys_check",
+        "nuclei_api_keys_results.json",
+        "Scanning for exposed API keys..."
+    )
+
+def find_backup_files(context: ScanContext) -> list:
+    """Looks for common backup file extensions using Nuclei."""
+    return _run_nuclei_template_scan(
+        context,
+        "backup_file_check",
+        "nuclei_backup_files_results.json",
+        "Searching for backup files..."
+    )
+
+def find_config_files(context: ScanContext) -> list:
+    """Looks for exposed configuration files using Nuclei."""
+    return _run_nuclei_template_scan(
+        context,
+        "config_file_check",
+        "nuclei_config_files_results.json",
+        "Searching for config files..."
+    )
 
 def run_sensitive_data_scans(context: ScanContext):
     """


### PR DESCRIPTION
This commit implements the Sensitive Data Exposure scanning module.

Key changes:
- Added `api_keys_check` to the configuration for running Nuclei templates.
- The `check_git_exposure` function now uses httpx to find exposed .git directories.
- The `find_api_keys`, `find_backup_files`, and `find_config_files` functions now use Nuclei with specific templates to find sensitive data.
- A helper function `_run_nuclei_template_scan` was added to reduce code duplication.