### PR TITLE
feat: Implement Slack alerting for critical findings

### DIFF
--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -126,6 +126,10 @@ tool_commands:
 sqlmap:
   tamper_scripts: "space2comment,randomcase,unmagicquotes"
 
+# Reporting and Alerting
+reporting:
+  slack_webhook_url: "" # Add your Slack Incoming Webhook URL here
+
 # Technology to Nuclei template mapping
 tech_to_template_map:
   "WordPress": "technologies/wordpress/"

--- a/cyberhunter_3d/core/vulnerability/scanner.py
+++ b/cyberhunter_3d/core/vulnerability/scanner.py
@@ -18,6 +18,7 @@ from .scanners import (
 )
 from ..validation.validator import validate_xss
 from ..sast.scanner import run_semgrep_scan
+from ...reporting.alerter import send_slack_alert
 
 log = logging.getLogger(__name__)
 
@@ -212,6 +213,19 @@ class VulnerabilityManager:
                 log.info("XSS validation phase completed.")
             except Exception as e:
                 log.error(f"An error occurred during the XSS validation phase: {e}")
+
+        # --- Alerting Phase ---
+        log.info("Checking for critical findings to alert on...")
+        webhook_url = self.config.get("reporting", {}).get("slack_webhook_url")
+        if webhook_url:
+            for category, findings in final_results.items():
+                for finding in findings:
+                    if isinstance(finding, dict):
+                        severity = finding.get("info", {}).get("severity")
+                        if severity == "critical":
+                            send_slack_alert(webhook_url, finding)
+        else:
+            log.info("Slack webhook URL not configured, skipping alerts.")
 
         log.info("All vulnerability scans and validation completed.")
         return final_results

--- a/cyberhunter_3d/reporting/alerter.py
+++ b/cyberhunter_3d/reporting/alerter.py
@@ -1,0 +1,62 @@
+import logging
+import requests
+import json
+
+log = logging.getLogger(__name__)
+
+def send_slack_alert(webhook_url: str, finding: dict):
+    """
+    Sends a formatted alert to a Slack webhook for a critical vulnerability.
+
+    Args:
+        webhook_url: The Slack Incoming Webhook URL.
+        finding: The vulnerability finding dictionary.
+    """
+    if not webhook_url:
+        log.debug("Slack webhook URL not configured. Skipping alert.")
+        return
+
+    try:
+        # Extract key information from the finding
+        name = finding.get("info", {}).get("name", "N/A")
+        severity = finding.get("info", {}).get("severity", "N/A").upper()
+        host = finding.get("host", "N/A")
+        matched_at = finding.get("matched-at", host) # Use matched-at if available, otherwise host
+        template_id = finding.get("template-id", "N/A")
+
+        # Construct a Slack Block Kit message
+        payload = {
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": f":warning: Critical Vulnerability Detected: {name}",
+                        "emoji": True
+                    }
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": f"*Severity:*\n`{severity}`"},
+                        {"type": "mrkdwn", "text": f"*Template:*\n`{template_id}`"},
+                        {"type": "mrkdwn", "text": f"*Host:*\n`{host}`"},
+                        {"type": "mrkdwn", "text": f"*Matched At:*\n`{matched_at}`"}
+                    ]
+                },
+                {
+                    "type": "divider"
+                }
+            ]
+        }
+
+        headers = {'Content-Type': 'application/json'}
+        response = requests.post(webhook_url, data=json.dumps(payload), headers=headers, timeout=10)
+
+        if response.status_code == 200:
+            log.info(f"Successfully sent Slack alert for finding: {name}")
+        else:
+            log.error(f"Failed to send Slack alert. Status: {response.status_code}, Response: {response.text}")
+
+    except Exception as e:
+        log.error(f"An error occurred while sending Slack alert: {e}")


### PR DESCRIPTION
This commit introduces a real-time alerting feature for critical vulnerabilities, integrating with Slack.

Key changes:
- The configuration file `recon_config.yaml` now has a `reporting` section to store a Slack webhook URL.
- A new `alerter.py` module has been added to `cyberhunter_3d/reporting/` to handle the formatting and sending of Slack messages.
- The `VulnerabilityManager` has been updated with a final "Alerting Phase". It iterates through results and sends a Slack notification for any finding with "critical" severity.
- The message is formatted using Slack's Block Kit for better readability.