### PR TITLE
feat: Add output and integration module

### DIFF
--- a/cyberhunter_3d/main.py
+++ b/cyberhunter_3d/main.py
@@ -8,6 +8,7 @@ from cyberhunter_3d.core.reconnaissance.utils import load_config
 from cyberhunter_3d.utils.logger import setup_logger
 from cyberhunter_3d.reporting.r2_uploader import upload_to_r2
 from cyberhunter_3d.utils.file_utils import get_results_dir
+from cyberhunter_3d.output import run_output_pipeline
 
 def aggregate_results(output_paths: dict, domain: str, logger, results_dir: str, scan_id: int):
     """
@@ -127,8 +128,10 @@ def aggregate_results(output_paths: dict, domain: str, logger, results_dir: str,
     try:
         with open(final_output_path, 'w') as f: json.dump(final_data, f, indent=4)
         logger.info(f"Successfully aggregated results to {final_output_path}")
+        return final_output_path
     except IOError as e:
         logger.error(f"Failed to write final aggregated file: {e}")
+        return None
 
 
 @click.command()
@@ -139,7 +142,8 @@ def aggregate_results(output_paths: dict, domain: str, logger, results_dir: str,
 @click.option("--previous-scan-dir", help="Path to the previous scan's output directory for delta detection.")
 @click.option("--url-discovery", is_flag=True, help="Run the URL discovery and vulnerability scanning phase.")
 @click.option("--generate-report", is_flag=True, help="Generate a PDF report after the scan.")
-def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_discovery, generate_report):
+@click.option("--run-output-pipeline", is_flag=True, help="Run the output and integration pipeline.")
+def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_discovery, generate_report, run_output_pipeline):
     """
     Main function to run the CyberHunter 3D reconnaissance V3 pipeline.
     """
@@ -181,10 +185,13 @@ def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_disco
         logger.info(f"Reconnaissance complete for {domain}.")
 
     # Always aggregate results at the end
-    aggregate_results({}, domain, logger, results_dir, scan_id)
+    final_file_path = aggregate_results({}, domain, logger, results_dir, scan_id)
+
+    if not final_file_path:
+        logger.error("Result aggregation failed. Skipping remaining steps.")
+        sys.exit(1)
 
     config = load_config()
-    final_file_path = os.path.join(config['recon_output_dir'], config['final_recon_file'])
     logger.info(f"All findings have been aggregated into: {final_file_path}")
 
     if upload_to_r2:
@@ -195,6 +202,14 @@ def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_disco
         from cyberhunter_3d.reporting.pdf_generator import generate_pdf_report
         logger.info("Generating PDF report...")
         generate_pdf_report(scan_id, domain, app)
+
+    if run_output_pipeline:
+        logger.info("Running output and integration pipeline...")
+        with open(final_file_path, 'r') as f:
+            results = json.load(f)
+
+        output_dir = os.path.join(config['recon_output_dir'], 'output')
+        run_output_pipeline(results, config, output_dir)
 
     logger.info("--- Pipeline Finished ---")
 

--- a/cyberhunter_3d/output/__init__.py
+++ b/cyberhunter_3d/output/__init__.py
@@ -1,0 +1,31 @@
+# This file is part of the CyberHunter 3D output module.
+import os
+from .file_handler import generate_output_files
+from .integrations.jira import create_jira_issue
+from .integrations.slack import send_slack_notification
+from .integrations.github import create_github_issue
+from .archive import create_archive
+
+def run_output_pipeline(results: dict, config: dict, output_dir: str):
+    """
+    Runs the entire output and integration pipeline.
+    """
+    # Generate output files
+    generate_output_files(results, output_dir)
+
+    # Send notifications and create issues
+    if config.get('jira'):
+        for vuln in results.get('vulnerabilities', []):
+            create_jira_issue(vuln, config['jira'])
+
+    if config.get('slack'):
+        send_slack_notification("Reconnaissance scan complete.", config['slack'])
+
+    if config.get('github'):
+        for vuln in results.get('vulnerabilities', []):
+            create_github_issue(vuln, config['github'])
+
+    # Archive the results
+    if config.get('archive'):
+        archive_path = os.path.join(output_dir, 'archive.zip')
+        create_archive(output_dir, archive_path)

--- a/cyberhunter_3d/output/archive.py
+++ b/cyberhunter_3d/output/archive.py
@@ -1,0 +1,28 @@
+import os
+import pyzipper
+
+def create_archive(output_dir: str, archive_path: str, encryption_key: str = None):
+    """
+    Creates a zip archive of the output files.
+    If an encryption_key is provided, the archive will be encrypted.
+    """
+    if not os.path.exists(output_dir):
+        print(f"Error: Output directory not found at {output_dir}")
+        return
+
+    if encryption_key:
+        with pyzipper.AESZipFile(archive_path, 'w', compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES) as zf:
+            zf.setpassword(encryption_key.encode())
+            for root, _, files in os.walk(output_dir):
+                for file in files:
+                    zf.write(os.path.join(root, file),
+                               os.path.relpath(os.path.join(root, file),
+                                               os.path.join(output_dir, '..')))
+    else:
+        import zipfile
+        with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            for root, _, files in os.walk(output_dir):
+                for file in files:
+                    zipf.write(os.path.join(root, file),
+                               os.path.relpath(os.path.join(root, file),
+                                               os.path.join(output_dir, '..')))

--- a/cyberhunter_3d/output/file_handler.py
+++ b/cyberhunter_3d/output/file_handler.py
@@ -1,0 +1,45 @@
+import os
+import json
+from typing import Dict, Any
+from . import utils
+
+def generate_output_files(results: Dict[str, Any], output_dir: str):
+    """
+    Generates all the output files from the aggregated results.
+    """
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    hosts = results.get('hosts', [])
+
+    # Generate Subdomain.txt
+    subdomains = utils.format_subdomains(hosts)
+    with open(os.path.join(output_dir, 'Subdomain.txt'), 'w') as f:
+        for subdomain in subdomains:
+            f.write(f"{subdomain}\n")
+
+    # Generate alive_domain.txt
+    alive_domains = utils.format_alive_domains(hosts)
+    with open(os.path.join(output_dir, 'alive_domain.txt'), 'w') as f:
+        for domain in alive_domains:
+            f.write(f"{domain}\n")
+
+    # Generate dead_domain.txt
+    dead_domains = utils.format_dead_domains(hosts)
+    with open(os.path.join(output_dir, 'dead_domain.txt'), 'w') as f:
+        for domain in dead_domains:
+            f.write(f"{domain}\n")
+
+    # Generate Way_kat.txt
+    url_discovery = results.get('url_discovery', {})
+    all_urls = []
+    all_urls.extend(url_discovery.get('alive_urls', []))
+    all_urls.extend(url_discovery.get('redirect_urls', []))
+    with open(os.path.join(output_dir, 'Way_kat.txt'), 'w') as f:
+        for url in all_urls:
+            f.write(f"{url}\n")
+
+    # Generate all_vulns.json
+    vulnerabilities = results.get('vulnerabilities', [])
+    with open(os.path.join(output_dir, 'all_vulns.json'), 'w') as f:
+        json.dump(vulnerabilities, f, indent=4)

--- a/cyberhunter_3d/output/integrations/__init__.py
+++ b/cyberhunter_3d/output/integrations/__init__.py
@@ -1,0 +1,1 @@
+# This file is part of the CyberHunter 3D integrations module.

--- a/cyberhunter_3d/output/integrations/github.py
+++ b/cyberhunter_3d/output/integrations/github.py
@@ -1,0 +1,9 @@
+# GitHub integration for CyberHunter 3D.
+
+def create_github_issue(vulnerability: dict, config: dict):
+    """
+    Creates a GitHub issue from a vulnerability finding.
+    """
+    # TODO: Implement GitHub integration logic.
+    print(f"Creating GitHub issue for: {vulnerability.get('name')}")
+    pass

--- a/cyberhunter_3d/output/integrations/jira.py
+++ b/cyberhunter_3d/output/integrations/jira.py
@@ -1,0 +1,43 @@
+# Jira integration for CyberHunter 3D.
+import requests
+from requests.auth import HTTPBasicAuth
+
+def create_jira_issue(vulnerability: dict, config: dict):
+    """
+    Creates a Jira issue from a vulnerability finding.
+    """
+    jira_url = config.get('url')
+    jira_user = config.get('user')
+    jira_token = config.get('token')
+    project_key = config.get('project_key')
+
+    if not all([jira_url, jira_user, jira_token, project_key]):
+        print("Error: Jira configuration is incomplete.")
+        return
+
+    url = f"{jira_url}/rest/api/2/issue"
+    auth = HTTPBasicAuth(jira_user, jira_token)
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+    }
+
+    payload = {
+        "fields": {
+            "project": {
+                "key": project_key
+            },
+            "summary": vulnerability.get('name'),
+            "description": vulnerability.get('description'),
+            "issuetype": {
+                "name": "Bug"
+            }
+        }
+    }
+
+    try:
+        response = requests.post(url, json=payload, headers=headers, auth=auth)
+        response.raise_for_status()
+        print(f"Jira issue created successfully: {response.json()['key']}")
+    except requests.exceptions.RequestException as e:
+        print(f"Error creating Jira issue: {e}")

--- a/cyberhunter_3d/output/integrations/slack.py
+++ b/cyberhunter_3d/output/integrations/slack.py
@@ -1,0 +1,22 @@
+# Slack integration for CyberHunter 3D.
+import requests
+
+def send_slack_notification(message: str, config: dict):
+    """
+    Sends a notification to Slack.
+    """
+    webhook_url = config.get('webhook_url')
+    if not webhook_url:
+        print("Error: Slack webhook URL not configured.")
+        return
+
+    payload = {
+        "text": message
+    }
+
+    try:
+        response = requests.post(webhook_url, json=payload)
+        response.raise_for_status()
+        print("Slack notification sent successfully.")
+    except requests.exceptions.RequestException as e:
+        print(f"Error sending Slack notification: {e}")

--- a/cyberhunter_3d/output/utils.py
+++ b/cyberhunter_3d/output/utils.py
@@ -1,0 +1,14 @@
+import json
+from typing import List, Dict, Any
+
+def format_subdomains(hosts: List[Dict[str, Any]]) -> List[str]:
+    """Extracts subdomains from a list of host dictionaries."""
+    return [host['host'] for host in hosts]
+
+def format_alive_domains(hosts: List[Dict[str, Any]]) -> List[str]:
+    """Extracts alive domains from a list of host dictionaries."""
+    return [host['host'] for host in hosts if host.get('alive')]
+
+def format_dead_domains(hosts: List[Dict[str, Any]]) -> List[str]:
+    """Extracts dead domains from a list of host dictionaries."""
+    return [host['host'] for host in hosts if not host.get('alive')]

--- a/cyberhunter_3d/tests/test_output.py
+++ b/cyberhunter_3d/tests/test_output.py
@@ -1,0 +1,100 @@
+import os
+import json
+import unittest
+import zipfile
+from unittest.mock import patch, mock_open
+from cyberhunter_3d.output.file_handler import generate_output_files
+from cyberhunter_3d.output.archive import create_archive
+from cyberhunter_3d.output.integrations.slack import send_slack_notification
+from cyberhunter_3d.output.integrations.jira import create_jira_issue
+
+class TestOutputModule(unittest.TestCase):
+
+    def setUp(self):
+        self.results = {
+            "hosts": [
+                {"host": "test.com", "alive": True},
+                {"host": "dead.com", "alive": False},
+            ],
+            "url_discovery": {
+                "alive_urls": ["http://test.com/1"],
+                "redirect_urls": ["http://test.com/2"],
+            },
+            "vulnerabilities": [
+                {"name": "SQL Injection", "severity": "High"}
+            ]
+        }
+        self.output_dir = "test_output"
+
+    def tearDown(self):
+        if os.path.exists(self.output_dir):
+            for file in os.listdir(self.output_dir):
+                os.remove(os.path.join(self.output_dir, file))
+            os.rmdir(self.output_dir)
+
+    @patch("os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_generate_output_files(self, mock_file, mock_makedirs):
+        generate_output_files(self.results, self.output_dir)
+
+        mock_makedirs.assert_called_once_with(self.output_dir)
+
+        # Check that the correct files were opened for writing
+        expected_files = [
+            os.path.join(self.output_dir, 'Subdomain.txt'),
+            os.path.join(self.output_dir, 'alive_domain.txt'),
+            os.path.join(self.output_dir, 'dead_domain.txt'),
+            os.path.join(self.output_dir, 'Way_kat.txt'),
+            os.path.join(self.output_dir, 'all_vulns.json'),
+        ]
+
+        opened_files = {call[0][0] for call in mock_file.call_args_list}
+        self.assertEqual(set(expected_files), opened_files)
+
+    @patch("zipfile.ZipFile")
+    def test_create_archive(self, mock_zipfile):
+        # Create a dummy file in the output directory
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+        with open(os.path.join(self.output_dir, "test.txt"), "w") as f:
+            f.write("test")
+
+        archive_path = os.path.join(self.output_dir, "archive.zip")
+        create_archive(self.output_dir, archive_path)
+
+        mock_zipfile.assert_called_once_with(archive_path, 'w', zipfile.ZIP_DEFLATED)
+
+    @patch("pyzipper.AESZipFile")
+    def test_create_encrypted_archive(self, mock_zipfile):
+        # Create a dummy file in the output directory
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+        with open(os.path.join(self.output_dir, "test.txt"), "w") as f:
+            f.write("test")
+
+        archive_path = os.path.join(self.output_dir, "archive.zip")
+        create_archive(self.output_dir, archive_path, "password")
+
+        mock_zipfile.assert_called_once_with(archive_path, 'w', compression=unittest.mock.ANY, encryption=unittest.mock.ANY)
+
+    @patch("requests.post")
+    def test_send_slack_notification(self, mock_post):
+        config = {"webhook_url": "http://fake.slack.webhook"}
+        send_slack_notification("test message", config)
+        mock_post.assert_called_once_with(config["webhook_url"], json={"text": "test message"})
+
+    @patch("requests.post")
+    def test_create_jira_issue(self, mock_post):
+        config = {
+            "url": "http://fake.jira.url",
+            "user": "user",
+            "token": "token",
+            "project_key": "PROJ"
+        }
+        vuln = {"name": "test vuln", "description": "test desc"}
+        create_jira_issue(vuln, config)
+        mock_post.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cyberhunter_3d/web/api.py
+++ b/cyberhunter_3d/web/api.py
@@ -1,8 +1,10 @@
+import os
 from functools import wraps
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, send_from_directory
 from .models import User, db, Scan, Target, Asset
 from cyberhunter_3d.core.target_parser import parse_targets
 from cyberhunter_3d.core.scan_manager import run_discovery_phase
+from cyberhunter_3d.output import run_output_pipeline
 from concurrent.futures import ThreadPoolExecutor
 from flask import current_app
 
@@ -157,3 +159,52 @@ def get_scan_graph(scan_id):
         graph_definition += f'    {scan_node} --> {asset_node}\n'
 
     return jsonify({'graph_definition': graph_definition})
+
+@api_bp.route('/scans/<int:scan_id>/output/<path:filename>', methods=['GET'])
+@require_api_key
+def get_output_file(scan_id, filename):
+    scan = Scan.query.get_or_404(scan_id)
+    user = User.query.filter_by(api_key=request.headers.get('X-API-Key')).first()
+    if scan.user_id != user.id:
+        return jsonify({'error': 'Forbidden'}), 403
+
+    # This is a simplified example; in a real app, you'd get the domain
+    # from the scan object and construct the path more robustly.
+    domain = scan.targets[0].value if scan.targets else 'default'
+
+    # Assuming a structure like: <recon_output_dir>/<domain>_<scan_id>/output/
+    output_dir = os.path.join(
+        current_app.config['RECON_OUTPUT_DIR'],
+        f"{domain}_{scan_id}",
+        'output'
+    )
+
+    return send_from_directory(output_dir, filename, as_attachment=True)
+
+@api_bp.route('/scans/<int:scan_id>/output', methods=['POST'])
+@require_api_key
+def trigger_output_pipeline(scan_id):
+    scan = Scan.query.get_or_404(scan_id)
+    user = User.query.filter_by(api_key=request.headers.get('X-API-Key')).first()
+    if scan.user_id != user.id:
+        return jsonify({'error': 'Forbidden'}), 403
+
+    if scan.status not in ['COMPLETED', 'PENDING_REVIEW']:
+        return jsonify({'message': 'Scan is not yet complete.'}), 400
+
+    domain = scan.targets[0].value if scan.targets else 'default'
+    results_dir = os.path.join(current_app.config['RECON_OUTPUT_DIR'], f"{domain}_{scan_id}")
+    final_file_path = os.path.join(results_dir, current_app.config['FINAL_RECON_FILE'])
+
+    if not os.path.exists(final_file_path):
+        return jsonify({'error': 'Aggregated results not found.'}), 404
+
+    with open(final_file_path, 'r') as f:
+        results = json.load(f)
+
+    output_dir = os.path.join(results_dir, 'output')
+
+    # This will run in a thread to avoid blocking the request
+    get_executor().submit(run_output_pipeline, results, current_app.config, output_dir)
+
+    return jsonify({'message': 'Output pipeline triggered successfully.'}), 202

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ pdfkit
 lightgbm
 pandas
 scikit-learn
+pyzipper
+requests


### PR DESCRIPTION
This commit adds a new `output` module to the CyberHunter 3D application. This module provides functionality for generating various output files, integrating with external services, and archiving results.

The new module includes:
- File handlers for generating `Subdomain.txt`, `Way_kat.txt`, `alive_domain.txt`, `dead_domain.txt`, and `all_vulns.json`.
- Integrations with Slack and Jira for sending notifications and creating issues.
- Support for creating encrypted zip archives of the output files using `pyzipper`.
- A new `run_output_pipeline` function to orchestrate the output and integration steps.
- A new `--run-output-pipeline` command-line flag to trigger the pipeline from `main.py`.
- New API endpoints to trigger the output pipeline and download output files.
- Unit tests for the new functionality.