### PR TITLE
feat: Add Network Scan Module

### DIFF
--- a/cyberhunter_3d/core/plugins/impl/network_scan_masscan.py
+++ b/cyberhunter_3d/core/plugins/impl/network_scan_masscan.py
@@ -1,0 +1,96 @@
+import logging
+import subprocess
+import json
+import tempfile
+import os
+from typing import Dict, Any
+
+from ..base import Plugin
+from ..context import ScanContext
+
+log = logging.getLogger(__name__)
+
+class MasscanScanPlugin(Plugin):
+    """
+    Masscan Scan Plugin to discover open ports.
+    """
+    @property
+    def name(self) -> str:
+        return "Masscan Scan"
+
+    @property
+    def description(self) -> str:
+        return "Performs a Masscan scan to discover open ports."
+
+    @property
+    def requires(self) -> list[str]:
+        return ["validated_subdomains"]
+
+    @property
+    def provides(self) -> list[str]:
+        return ["open_ports"]
+
+    def run(self, context: ScanContext):
+        subdomains = context.get("validated_subdomains")
+        if not subdomains:
+            log.info("No validated subdomains found, skipping Masscan scan.")
+            return
+
+        log.info(f"Running Masscan scan on {len(subdomains)} subdomains.")
+        open_ports: Dict[str, Any] = context.get("open_ports", {})
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+            for subdomain in subdomains:
+                tmp_file.write(subdomain + '\n')
+            target_file = tmp_file.name
+
+        # Create a temporary file for the output
+        output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        output_file.close()
+
+        try:
+            # -iL: Input from list of hosts/networks
+            # -oJ: Output in JSON format
+            # --rate: The rate in packets/second
+            command = [
+                "masscan",
+                "-iL",
+                target_file,
+                "-oJ",
+                output_file.name,
+                "--rate",
+                "1000" # Default rate
+            ]
+            subprocess.run(command, capture_output=True, text=True, check=True)
+
+            with open(output_file.name, 'r') as f:
+                # Masscan produces a stream of JSON objects, not a single valid JSON array.
+                # We need to read each line and parse it as a separate JSON object.
+                # The last line could be a "finished" message, so we skip it if it is not a valid json.
+                for line in f:
+                    if line.startswith('{'):
+                        try:
+                            data = json.loads(line.strip(','))
+                            ip = data.get('ip')
+                            port_info = data.get('ports')[0]
+                            port = port_info.get('port')
+                            if ip and port:
+                                # masscan gives ip, not hostname. We need to resolve it.
+                                # For now, we will store by IP. A separate plugin could do the resolution.
+                                if ip not in open_ports:
+                                    open_ports[ip] = []
+                                if port not in open_ports[ip]:
+                                    open_ports[ip].append(port)
+                        except json.JSONDecodeError:
+                            log.warning(f"Could not parse line from masscan output: {line}")
+
+            log.info(f"Masscan scan completed. Found open ports on {len(open_ports)} hosts.")
+
+        except FileNotFoundError:
+            log.error("masscan not found. Please ensure it is installed and in your PATH.")
+        except subprocess.CalledProcessError as e:
+            log.error(f"Masscan scan failed: {e.stderr}")
+        finally:
+            os.remove(target_file)
+            os.remove(output_file.name)
+            context.set("open_ports", open_ports)

--- a/cyberhunter_3d/core/plugins/impl/network_scan_naabu.py
+++ b/cyberhunter_3d/core/plugins/impl/network_scan_naabu.py
@@ -1,0 +1,79 @@
+import logging
+import subprocess
+import json
+import tempfile
+import os
+from typing import Dict, Any
+
+from ..base import Plugin
+from ..context import ScanContext
+
+log = logging.getLogger(__name__)
+
+class NaabuScanPlugin(Plugin):
+    """
+    Naabu Scan Plugin to discover open ports.
+    """
+    @property
+    def name(self) -> str:
+        return "Naabu Scan"
+
+    @property
+    def description(self) -> str:
+        return "Performs a Naabu scan to discover open ports."
+
+    @property
+    def requires(self) -> list[str]:
+        return ["validated_subdomains"]
+
+    @property
+    def provides(self) -> list[str]:
+        return ["open_ports"]
+
+    def run(self, context: ScanContext):
+        subdomains = context.get("validated_subdomains")
+        if not subdomains:
+            log.info("No validated subdomains found, skipping Naabu scan.")
+            return
+
+        log.info(f"Running Naabu scan on {len(subdomains)} subdomains.")
+        open_ports: Dict[str, Any] = context.get("open_ports", {})
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+            for subdomain in subdomains:
+                tmp_file.write(subdomain + '\n')
+            target_file = tmp_file.name
+
+        try:
+            # -iL: Input from list of hosts/networks
+            # -json: Output in json format
+            command = [
+                "naabu",
+                "-iL",
+                target_file,
+                "-json"
+            ]
+            result = subprocess.run(command, capture_output=True, text=True, check=True)
+
+            for line in result.stdout.strip().split('\n'):
+                try:
+                    data = json.loads(line)
+                    host = data.get('host')
+                    port = data.get('port')
+                    if host and port:
+                        if host not in open_ports:
+                            open_ports[host] = []
+                        if port not in open_ports[host]:
+                            open_ports[host].append(port)
+                except json.JSONDecodeError:
+                    log.warning(f"Could not parse line from naabu output: {line}")
+
+            log.info(f"Naabu scan completed. Found open ports on {len(open_ports)} hosts.")
+
+        except FileNotFoundError:
+            log.error("naabu not found. Please ensure it is installed and in your PATH.")
+        except subprocess.CalledProcessError as e:
+            log.error(f"Naabu scan failed: {e.stderr}")
+        finally:
+            os.remove(target_file)
+            context.set("open_ports", open_ports)

--- a/cyberhunter_3d/core/plugins/impl/network_scan_nmap.py
+++ b/cyberhunter_3d/core/plugins/impl/network_scan_nmap.py
@@ -1,0 +1,103 @@
+import logging
+import subprocess
+import xml.etree.ElementTree as ET
+import tempfile
+import os
+from typing import Dict, Any
+
+from ..base import Plugin
+from ..context import ScanContext
+
+log = logging.getLogger(__name__)
+
+class NmapScanPlugin(Plugin):
+    """
+    Nmap Scan Plugin to discover open ports and services.
+    """
+    @property
+    def name(self) -> str:
+        return "Nmap Scan"
+
+    @property
+    def description(self) -> str:
+        return "Performs an Nmap scan to discover open ports and services."
+
+    @property
+    def requires(self) -> list[str]:
+        return ["validated_subdomains"]
+
+    @property
+    def provides(self) -> list[str]:
+        return ["open_ports", "services"]
+
+    def run(self, context: ScanContext):
+        subdomains = context.get("validated_subdomains")
+        if not subdomains:
+            log.info("No validated subdomains found, skipping Nmap scan.")
+            return
+
+        log.info(f"Running Nmap scan on {len(subdomains)} subdomains.")
+        open_ports: Dict[str, Any] = context.get("open_ports", {})
+        services: Dict[str, Any] = context.get("services", {})
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+            for subdomain in subdomains:
+                tmp_file.write(subdomain + '\n')
+            target_file = tmp_file.name
+
+        try:
+            # -sV: Probe open ports to determine service/version info
+            # -oX -: Output scan in XML format to stdout
+            # -iL: Input from list of hosts/networks
+            # --open: Only show open (or possibly open) ports
+            command = [
+                "nmap",
+                "-sV",
+                "-oX",
+                "-",
+                "-iL",
+                target_file,
+                "--open"
+            ]
+            result = subprocess.run(command, capture_output=True, text=True, check=True)
+
+            tree = ET.fromstring(result.stdout)
+
+            for host in tree.findall('host'):
+                ip_address = host.find('address').get('addr')
+                hostname_element = host.find('hostnames/hostname')
+                hostname = hostname_element.get('name') if hostname_element is not None else ip_address
+
+                if hostname not in open_ports:
+                    open_ports[hostname] = []
+                if hostname not in services:
+                    services[hostname] = []
+
+                for port in host.findall('ports/port'):
+                    port_id = int(port.get('portid'))
+                    state = port.find('state').get('state')
+                    if state == 'open':
+                        open_ports[hostname].append(port_id)
+
+                        service_info = {}
+                        service_element = port.find('service')
+                        if service_element is not None:
+                            service_info['port'] = port_id
+                            service_info['name'] = service_element.get('name', 'unknown')
+                            service_info['product'] = service_element.get('product', '')
+                            service_info['version'] = service_element.get('version', '')
+                            service_info['extrainfo'] = service_element.get('extrainfo', '')
+                            services[hostname].append(service_info)
+
+            log.info(f"Nmap scan completed. Found open ports on {len(open_ports)} hosts.")
+
+        except FileNotFoundError:
+            log.error("nmap not found. Please ensure it is installed and in your PATH.")
+        except subprocess.CalledProcessError as e:
+            log.error(f"Nmap scan failed: {e.stderr}")
+        except ET.ParseError as e:
+            log.error(f"Failed to parse Nmap XML output: {e}")
+        finally:
+            os.remove(target_file)
+            context.set("open_ports", open_ports)
+            context.set("services", services)

--- a/cyberhunter_3d/scripts/install_tools.sh
+++ b/cyberhunter_3d/scripts/install_tools.sh
@@ -14,7 +14,7 @@ echo "Starting installation of CyberHunter 3D V2 reconnaissance tools..."
 # --- System package installation (apt) ---
 echo "Installing system packages..."
 apt-get update
-apt-get install -y nmap gobuster libpcap-dev firefox git wget unzip wkhtmltopdf sqlmap golang-go
+apt-get install -y nmap masscan gobuster libpcap-dev firefox git wget unzip wkhtmltopdf sqlmap golang-go
 echo "System packages installed successfully."
 
 # --- Go tools installation ---

--- a/cyberhunter_3d/tests/test_network_scan_masscan.py
+++ b/cyberhunter_3d/tests/test_network_scan_masscan.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import tempfile
+import os
+
+from cyberhunter_3d.core.plugins.impl.network_scan_masscan import MasscanScanPlugin
+from cyberhunter_3d.core.plugins.context import ScanContext
+
+class TestMasscanScanPlugin(unittest.TestCase):
+
+    @patch('os.remove')
+    @patch('subprocess.run')
+    @patch('tempfile.NamedTemporaryFile')
+    def test_run_masscan_scan(self, mock_tempfile, mock_subprocess_run, mock_os_remove):
+        # Mock the subprocess.run call
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.check_returncode.return_value = None
+        mock_subprocess_run.return_value = mock_result
+
+        # Mock the tempfile
+        mock_output_file = MagicMock()
+        mock_output_file.name = "/tmp/masscan_output.json"
+
+        # The first call to NamedTemporaryFile is for the input file
+        # The second call is for the output file
+        mock_tempfile.side_effect = [
+            MagicMock(), # for the input file
+            mock_output_file
+        ]
+
+        # Create a dummy masscan output file
+        masscan_output = [
+            {"ip": "127.0.0.1", "timestamp": "1628582400", "ports": [{"port": 80, "proto": "tcp", "status": "open", "reason": "syn-ack", "ttl": 64}]},
+            {"ip": "127.0.0.1", "timestamp": "1628582401", "ports": [{"port": 443, "proto": "tcp", "status": "open", "reason": "syn-ack", "ttl": 64}]}
+        ]
+
+        # Write the dummy output to the mocked file
+        with open(mock_output_file.name, 'w') as f:
+            for item in masscan_output:
+                f.write(json.dumps(item) + '\n')
+
+
+        # Setup the plugin and context
+        plugin = MasscanScanPlugin()
+        context = ScanContext(target_domain="example.com", scan_id=1, results_dir="/tmp")
+        context.set("validated_subdomains", {"localhost"})
+
+        # Run the plugin
+        plugin.run(context)
+
+        # Assert the results
+        open_ports = context.get("open_ports")
+
+        self.assertIn("127.0.0.1", open_ports)
+        self.assertEqual(sorted(open_ports["127.0.0.1"]), [80, 443])
+
+        # Cleanup the dummy file
+        os.remove(mock_output_file.name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cyberhunter_3d/tests/test_network_scan_naabu.py
+++ b/cyberhunter_3d/tests/test_network_scan_naabu.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from cyberhunter_3d.core.plugins.impl.network_scan_naabu import NaabuScanPlugin
+from cyberhunter_3d.core.plugins.context import ScanContext
+
+class TestNaabuScanPlugin(unittest.TestCase):
+
+    @patch('subprocess.run')
+    def test_run_naabu_scan(self, mock_subprocess_run):
+        # Mock the subprocess.run call
+        mock_result = MagicMock()
+        mock_result.stdout = """
+        {"host": "localhost", "port": 80, "ip": "127.0.0.1"}
+        {"host": "localhost", "port": 443, "ip": "127.0.0.1"}
+        """
+        mock_result.stderr = ""
+        mock_result.check_returncode.return_value = None
+        mock_subprocess_run.return_value = mock_result
+
+        # Setup the plugin and context
+        plugin = NaabuScanPlugin()
+        context = ScanContext(target_domain="example.com", scan_id=1, results_dir="/tmp")
+        context.set("validated_subdomains", {"localhost"})
+
+        # Run the plugin
+        plugin.run(context)
+
+        # Assert the results
+        open_ports = context.get("open_ports")
+
+        self.assertIn("localhost", open_ports)
+        self.assertEqual(sorted(open_ports["localhost"]), [80, 443])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cyberhunter_3d/tests/test_network_scan_nmap.py
+++ b/cyberhunter_3d/tests/test_network_scan_nmap.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import textwrap
+from cyberhunter_3d.core.plugins.impl.network_scan_nmap import NmapScanPlugin
+from cyberhunter_3d.core.plugins.context import ScanContext
+
+class TestNmapScanPlugin(unittest.TestCase):
+
+    @patch('subprocess.run')
+    def test_run_nmap_scan(self, mock_subprocess_run):
+        # Mock the subprocess.run call
+        mock_result = MagicMock()
+        mock_result.stdout = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE nmaprun>
+        <nmaprun scanner="nmap" args="nmap -sV -oX - -iL /tmp/tmp_nmap_targets" start="1628582400" version="7.91" xmloutputversion="1.05">
+            <host>
+                <address addr="127.0.0.1" addrtype="ipv4"/>
+                <hostnames>
+                    <hostname name="localhost" type="user"/>
+                </hostnames>
+                <ports>
+                    <port protocol="tcp" portid="80">
+                        <state state="open" reason="syn-ack" reason_ttl="0"/>
+                        <service name="http" product="Apache httpd" version="2.4.41" extrainfo="(Ubuntu)" method="probed" conf="10"/>
+                    </port>
+                    <port protocol="tcp" portid="443">
+                        <state state="open" reason="syn-ack" reason_ttl="0"/>
+                        <service name="https" product="Apache httpd" version="2.4.41" extrainfo="(Ubuntu)" method="probed" conf="10"/>
+                    </port>
+                </ports>
+            </host>
+        </nmaprun>
+        """)
+        mock_result.stderr = ""
+        mock_result.check_returncode.return_value = None
+        mock_subprocess_run.return_value = mock_result
+
+        # Setup the plugin and context
+        plugin = NmapScanPlugin()
+        context = ScanContext(target_domain="example.com", scan_id=1, results_dir="/tmp")
+        context.set("validated_subdomains", {"localhost"})
+
+        # Run the plugin
+        plugin.run(context)
+
+        # Assert the results
+        open_ports = context.get("open_ports")
+        services = context.get("services")
+
+        self.assertIn("localhost", open_ports)
+        self.assertEqual(open_ports["localhost"], [80, 443])
+
+        self.assertIn("localhost", services)
+        self.assertEqual(len(services["localhost"]), 2)
+        self.assertEqual(services["localhost"][0]["port"], 80)
+        self.assertEqual(services["localhost"][0]["name"], "http")
+        self.assertEqual(services["localhost"][1]["port"], 443)
+        self.assertEqual(services["localhost"][1]["name"], "https")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new network scanning module to the CyberHunter 3D application. The module follows the existing plugin-based architecture and adds support for three network scanning tools:
- Nmap
- Naabu
- Masscan

The new plugins are integrated into the reconnaissance pipeline and are executed in parallel, orchestrated by the PluginManager. They consume a list of validated subdomains and produce a list of open ports and services.

The following changes are included:
- Added `masscan` to the `install_tools.sh` script.
- Created new plugins for Nmap, Naabu, and Masscan in `cyberhunter_3d/core/plugins/impl/`.
- Added unit tests for each new plugin in `cyberhunter_3d/tests/`.