### PR TITLE
feat: Create directory structure for scan results

### DIFF
--- a/cyberhunter_3d/main.py
+++ b/cyberhunter_3d/main.py
@@ -8,7 +8,7 @@ from cyberhunter_3d.core.scan_manager import run_url_discovery_phase
 from cyberhunter_3d.core.reconnaissance.utils import load_config
 from cyberhunter_3d.utils.logger import setup_logger
 from cyberhunter_3d.reporting.r2_uploader import upload_to_r2
-from cyberhunter_3d.utils.file_utils import get_results_dir
+from cyberhunter_3d.utils.file_utils import get_results_dir, create_scan_results_structure
 from cyberhunter_3d.core.error_handler import handle_module_errors, CriticalError
 from cyberhunter_3d.core.health_checker import run_health_checks
 
@@ -178,6 +178,7 @@ def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_disco
         scan_id = scan.id
 
     results_dir = get_results_dir(domain, scan_id)
+    create_scan_results_structure(results_dir)
 
     try:
         scan_events = []

--- a/cyberhunter_3d/utils/file_utils.py
+++ b/cyberhunter_3d/utils/file_utils.py
@@ -23,3 +23,54 @@ def save_to_json(filename: str, data: Dict[str, Any], results_dir: str) -> str:
     except Exception as e:
         log.error(f"Error saving data to {filepath}: {e}")
         return ""
+
+def create_scan_results_structure(base_dir: str):
+    """
+    Creates the directory and file structure for the scan results.
+    """
+    log.info(f"Creating scan results structure in {base_dir}")
+
+    structure = {
+        "Scan Results Database": {
+            "Subdomain Results": [
+                "Subdomain.txt",
+                "subdomains_alive.txt",
+                "subdomains_dead.txt",
+                "subdomain_metadata.json"
+            ],
+            "URL Discovery Results": [
+                "Way_kat.txt",
+                "alive_domain.txt",
+                "dead_domain.txt",
+                "api_endpoints.txt",
+                "interesting_params.txt"
+            ],
+            "Vulnerability Findings": [
+                "critical_vulns.json",
+                "xss_findings.txt",
+                "sqli_results.txt",
+                "sensitive_exposure.txt",
+                "vulnerability_summary.json"
+            ],
+            "Reports": [
+                "executive_report.pdf",
+                "technical_details.html",
+                "remediation_guide.docx",
+                "raw_data_export.json"
+            ]
+        }
+    }
+
+    for root, content in structure.items():
+        root_path = os.path.join(base_dir, root)
+        os.makedirs(root_path, exist_ok=True)
+
+        if isinstance(content, dict):
+            for subdir, files in content.items():
+                subdir_path = os.path.join(root_path, subdir)
+                os.makedirs(subdir_path, exist_ok=True)
+                for file in files:
+                    file_path = os.path.join(subdir_path, file)
+                    with open(file_path, 'w') as f:
+                        pass
+    log.info("Scan results structure created successfully.")


### PR DESCRIPTION
This commit introduces a new function `create_scan_results_structure` in `cyberhunter_3d/utils/file_utils.py`. This function creates a standardized directory and file structure for storing scan results, as requested by the user.

The new function is called from `cyberhunter_3d/main.py` after the main results directory for a scan is created. This ensures that all scans will have a consistent and predictable output structure.

The created structure is as follows:

- Scan Results Database/
  - Subdomain Results/
    - Subdomain.txt
    - subdomains_alive.txt
    - subdomains_dead.txt
    - subdomain_metadata.json
  - URL Discovery Results/
    - Way_kat.txt
    - alive_domain.txt
    - dead_domain.txt
    - api_endpoints.txt
    - interesting_params.txt
  - Vulnerability Findings/
    - critical_vulns.json
    - xss_findings.txt
    - sqli_results.txt
    - sensitive_exposure.txt
    - vulnerability_summary.json
  - Reports/
    - executive_report.pdf
    - technical_details.html
    - remediation_guide.docx
    - raw_data_export.json