### PR TITLE
feat: Implement autonomous scanning with HackerOne integration

### DIFF
--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -154,3 +154,8 @@ data_pipeline:
   out_of_scope_rules: |
     api.example.com
     *.dev.example.com
+
+# HackerOne API credentials
+hackerone:
+  api_user: ""
+  api_key: ""

--- a/cyberhunter_3d/core/data_pipeline.py
+++ b/cyberhunter_3d/core/data_pipeline.py
@@ -4,7 +4,7 @@ from typing import Deque, List, Tuple
 from .target_parser import parse_targets
 from .scope_validator import ScopeValidator
 from .reconnaissance.utils import load_config
-from .feeds.crtsh_client import get_subdomains_from_crtsh
+from .feeds.hackerone_client import get_hackerone_scopes
 
 
 class DataPipeline:
@@ -12,22 +12,28 @@ class DataPipeline:
     A data processing pipeline to validate, normalize, and prioritize targets.
     """
 
-    def __init__(self, config: dict = None):
+    def __init__(self, config: dict = None, in_scope_rules: str = None, out_of_scope_rules: str = None):
         """
-        Initializes the pipeline with scope validation rules from a config.
+        Initializes the pipeline with scope validation rules.
 
         :param config: A dictionary containing the application configuration.
-                       If None, the config is loaded from the default file.
+        :param in_scope_rules: A string of in-scope rules. Overrides config if provided.
+        :param out_of_scope_rules: A string of out-of-scope rules. Overrides config if provided.
         """
         if config is None:
             config = load_config()
 
-        pipeline_config = config.get('data_pipeline', {})
-        in_scope_rules = pipeline_config.get('in_scope_rules', '')
-        out_of_scope_rules = pipeline_config.get('out_of_scope_rules', '')
+        if in_scope_rules is None or out_of_scope_rules is None:
+            pipeline_config = config.get('data_pipeline', {})
+            in_scope_rules = in_scope_rules or pipeline_config.get('in_scope_rules', '')
+            out_of_scope_rules = out_of_scope_rules or pipeline_config.get('out_of_scope_rules', '')
 
         self.scope_validator = ScopeValidator(in_scope_rules, out_of_scope_rules)
         self.processed_targets_queue: Deque[Tuple[str, str]] = deque()
+
+        hackerone_config = config.get('hackerone', {})
+        self.h1_user = hackerone_config.get('api_user')
+        self.h1_key = hackerone_config.get('api_key')
 
     def run(self, raw_targets: List[str]) -> Deque[Tuple[str, str]]:
         """
@@ -109,56 +115,16 @@ class DataPipeline:
         except IndexError:
             return None
 
-    def _fetch_autonomous_targets(self, seed_domain: str) -> List[str]:
+    def run_autonomous(self) -> List[dict]:
         """
-        Fetches a list of potential targets from autonomous sources.
+        Runs the pipeline in autonomous mode by fetching targets from HackerOne.
 
-        :param seed_domain: The domain to use as a seed for discovery.
-        :return: A list of raw target strings.
+        :return: A list of program dictionaries, each containing targets and scope.
         """
-        print(f"Fetching autonomous targets for seed: {seed_domain}")
-        # For now, we'll just use crt.sh. This can be expanded later.
-        subdomains = get_subdomains_from_crtsh(seed_domain)
-        # We also include the seed domain itself as a target.
-        subdomains.append(seed_domain)
-        return subdomains
+        if not self.h1_user or not self.h1_key:
+            print("HackerOne API user or key not configured. Skipping autonomous run.")
+            return []
 
-    def _generate_dynamic_scope(self, seed_domain: str):
-        """
-        Generates a dynamic scope based on a seed domain and re-initializes
-        the scope validator.
-
-        This will override any scope rules loaded from the config.
-
-        :param seed_domain: The domain to use for generating the scope.
-        """
-        print(f"Generating dynamic scope for seed: {seed_domain}")
-        # A simple dynamic scope: the domain and all its subdomains.
-        in_scope_rule = f"*.{seed_domain}\n{seed_domain}"
-
-        # For this simple case, we assume no out-of-scope rules are
-        # dynamically generated, but this could be expanded.
-        out_of_scope_rules = ""
-
-        # Re-initialize the scope validator with the new dynamic rules.
-        self.scope_validator = ScopeValidator(in_scope_rule, out_of_scope_rules)
-
-    def run_autonomous(self, seed_domain: str) -> Deque[Tuple[str, str]]:
-        """
-        Runs the pipeline in autonomous mode.
-
-        1. Generates a dynamic scope from the seed domain.
-        2. Fetches targets from autonomous sources.
-        3. Runs the standard processing pipeline on the fetched targets.
-
-        :param seed_domain: The domain to use as a seed for the run.
-        :return: A deque of processed, validated, and prioritized targets.
-        """
-        # Step 1: Generate dynamic scope
-        self._generate_dynamic_scope(seed_domain)
-
-        # Step 2: Fetch targets from autonomous sources
-        raw_targets = self._fetch_autonomous_targets(seed_domain)
-
-        # Step 3: Run the standard pipeline on the fetched targets
-        return self.run(raw_targets)
+        print("Running in autonomous mode...")
+        programs = get_hackerone_scopes(self.h1_user, self.h1_key)
+        return programs

--- a/cyberhunter_3d/main.py
+++ b/cyberhunter_3d/main.py
@@ -128,44 +128,12 @@ def aggregate_results(output_paths: dict, domain: str, logger, results_dir: str,
     except IOError as e:
         logger.error(f"Failed to write final aggregated file: {e}")
 
-
-@click.command()
-@click.option("-d", "--domain", required=True, help="The target domain for reconnaissance.")
-@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
-@click.option("--upload-to-r2", is_flag=True, help="Upload results to Cloudflare R2.")
-@click.option("--save-to-db", is_flag=True, help="Save the scan results to the database.")
-@click.option("--previous-scan-dir", help="Path to the previous scan's output directory for delta detection.")
-@click.option("--url-discovery", is_flag=True, help="Run the URL discovery and vulnerability scanning phase.")
-@click.option("--generate-report", is_flag=True, help="Generate a PDF report after the scan.")
-@click.option("--autonomous", is_flag=True, help="Run the data pipeline in autonomous mode for the given domain.")
-def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_discovery, generate_report, autonomous):
+def initiate_scan(domain: str, app, logger, url_discovery: bool, upload_to_r2: bool, generate_report: bool):
     """
-    Main function to run the CyberHunter 3D reconnaissance V3 pipeline.
+    Initiates a scan for a single domain.
     """
-    log_level = 'DEBUG' if verbose else 'INFO'
-    logger = setup_logger('main.log', level=log_level)
-    logger.info("--- Welcome to CyberHunter 3D - Reconnaissance Module (V3) ---")
-
-
-    # Run pre-scan health checks
-    if not run_health_checks():
-        logger.critical("Pre-scan health checks failed. Aborting scan.")
-        sys.exit(1)
-
-    if autonomous:
-        logger.info(f"Starting autonomous pipeline run for seed domain: {domain}")
-        pipeline = DataPipeline()
-        processed_targets = pipeline.run_autonomous(seed_domain=domain)
-        logger.info(f"Autonomous pipeline finished. Found {len(processed_targets)} targets.")
-        for target_value, target_type in processed_targets:
-            logger.info(f"  - Type: {target_type}, Value: {target_value}")
-        logger.info("--- Autonomous Run Finished ---")
-        return
-
-
-    from run_web import create_app
     from cyberhunter_3d.web.models import db, Scan, Target
-    app = create_app()
+    logger.info(f"Initiating scan for domain: {domain}")
     with app.app_context():
         # For CLI runs, we create a new scan object to track the operation.
         target = Target(value=domain, type='domain')
@@ -196,7 +164,7 @@ def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_disco
             )
             if not output_paths:
                 logger.error("Reconnaissance pipeline did not produce any output. Exiting.")
-                sys.exit(1)
+                return
             logger.info(f"Reconnaissance complete for {domain}.")
             scan_events = context.scan_events if context else []
 
@@ -217,11 +185,73 @@ def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_disco
             generate_pdf_report(scan_id, domain, app)
 
     except CriticalError as e:
-        logger.critical(f"A critical error occurred: {e}. The pipeline will now exit.")
-        sys.exit(1)
+        logger.critical(f"A critical error occurred during scan for {domain}: {e}.")
     except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
+        logger.error(f"An unexpected error occurred during scan for {domain}: {e}")
+
+@click.command()
+@click.option("-d", "--domain", required=False, help="The target domain for reconnaissance.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
+@click.option("--upload-to-r2", is_flag=True, help="Upload results to Cloudflare R2.")
+@click.option("--save-to-db", is_flag=True, help="Save the scan results to the database.")
+@click.option("--previous-scan-dir", help="Path to the previous scan's output directory for delta detection.")
+@click.option("--url-discovery", is_flag=True, help="Run the URL discovery and vulnerability scanning phase.")
+@click.option("--generate-report", is_flag=True, help="Generate a PDF report after the scan.")
+@click.option("--autonomous", is_flag=True, help="Run the data pipeline in autonomous mode for the given domain.")
+def main(domain, verbose, upload_to_r2, save_to_db, previous_scan_dir, url_discovery, generate_report, autonomous):
+    """
+    Main function to run the CyberHunter 3D reconnaissance V3 pipeline.
+    """
+    log_level = 'DEBUG' if verbose else 'INFO'
+    logger = setup_logger('main.log', level=log_level)
+    logger.info("--- Welcome to CyberHunter 3D - Reconnaissance Module (V3) ---")
+
+
+    # Run pre-scan health checks
+    if not run_health_checks():
+        logger.critical("Pre-scan health checks failed. Aborting scan.")
         sys.exit(1)
+
+    if autonomous:
+        logger.info("Starting autonomous pipeline run...")
+        from run_web import create_app
+        app = create_app()
+
+        pipeline = DataPipeline()
+        programs = pipeline.run_autonomous()
+
+        logger.info(f"Autonomous pipeline will scan {len(programs)} programs.")
+
+        for program in programs:
+            program_name = program.get('name', 'unknown-program')
+            logger.info(f"Processing program: {program_name}")
+
+            in_scope_rules = program.get('in_scope_rules', '')
+            out_of_scope_rules = program.get('out_of_scope_rules', '')
+
+            program_pipeline = DataPipeline(
+                in_scope_rules=in_scope_rules,
+                out_of_scope_rules=out_of_scope_rules
+            )
+
+            validated_targets = program_pipeline.run(program.get('targets', []))
+
+            logger.info(f"Found {len(validated_targets)} in-scope targets for {program_name}.")
+
+            for target, _ in validated_targets:
+                initiate_scan(target, app, logger, url_discovery, upload_to_r2, generate_report)
+
+        logger.info("--- Autonomous Run Finished ---")
+        return
+
+    if not domain:
+        logger.error("A domain must be provided if not running in autonomous mode.")
+        sys.exit(1)
+
+
+    from run_web import create_app
+    app = create_app()
+    initiate_scan(domain, app, logger, url_discovery, upload_to_r2, generate_report)
 
     logger.info("--- Pipeline Finished ---")
 

--- a/cyberhunter_3d/tests/test_data_pipeline.py
+++ b/cyberhunter_3d/tests/test_data_pipeline.py
@@ -13,6 +13,10 @@ class TestDataPipeline(unittest.TestCase):
             'data_pipeline': {
                 'in_scope_rules': '*.example.com',
                 'out_of_scope_rules': 'dev.example.com'
+            },
+            'hackerone': {
+                'api_user': 'test_user',
+                'api_key': 'test_key'
             }
         }
 
@@ -23,6 +27,8 @@ class TestDataPipeline(unittest.TestCase):
         # Check that the rules from the mock config were loaded
         self.assertEqual(len(pipeline.scope_validator.in_scope_patterns), 1)
         self.assertEqual(len(pipeline.scope_validator.out_of_scope_patterns), 1)
+        self.assertEqual(pipeline.h1_user, 'test_user')
+        self.assertEqual(pipeline.h1_key, 'test_key')
 
     @patch('cyberhunter_3d.core.data_pipeline.load_config')
     def test_pipeline_initialization_loads_default_config(self, mock_load_config):
@@ -71,52 +77,26 @@ class TestDataPipeline(unittest.TestCase):
         self.assertEqual(prioritized_queue.popleft(), ("test.example.com", "domain"))
         self.assertEqual(prioritized_queue.popleft(), ("192.168.1.1", "ip_address"))
 
-    @patch('cyberhunter_3d.core.data_pipeline.get_subdomains_from_crtsh')
-    def test_fetch_autonomous_targets(self, mock_get_subdomains):
-        """Test the autonomous target fetching method."""
-        mock_get_subdomains.return_value = ["sub1.example.com", "sub2.example.com"]
-        pipeline = DataPipeline(config=self.mock_config)
-        targets = pipeline._fetch_autonomous_targets("example.com")
-        mock_get_subdomains.assert_called_once_with("example.com")
-        self.assertIn("sub1.example.com", targets)
-        self.assertIn("sub2.example.com", targets)
-        self.assertIn("example.com", targets) # Seed domain should be included
-        self.assertEqual(len(targets), 3)
-
-    def test_generate_dynamic_scope(self):
-        """Test the dynamic scope generation."""
-        pipeline = DataPipeline(config=self.mock_config)
-        seed_domain = "new-scope.com"
-        pipeline._generate_dynamic_scope(seed_domain)
-
-        # Check that the validator was replaced with one with the new rules
-        self.assertTrue(pipeline.scope_validator.is_in_scope("test.new-scope.com"))
-        self.assertTrue(pipeline.scope_validator.is_in_scope("new-scope.com"))
-        self.assertFalse(pipeline.scope_validator.is_in_scope("another.com"))
-        # Check that the original config rules are gone
-        self.assertFalse(pipeline.scope_validator.is_in_scope("test.example.com"))
-
-    @patch('cyberhunter_3d.core.data_pipeline.DataPipeline._fetch_autonomous_targets')
-    def test_run_autonomous_mode(self, mock_fetch_targets):
+    @patch('cyberhunter_3d.core.data_pipeline.get_hackerone_scopes')
+    def test_run_autonomous_mode(self, mock_get_h1_scopes):
         """Test the end-to-end autonomous run."""
-        mock_fetch_targets.return_value = [
-            "www.autonomous.com",
-            "api.autonomous.com",
-            "www.autonomous.com" # Duplicate
+        mock_programs = [
+            {
+                'name': 'test-program',
+                'targets': ['a.example.com', 'b.example.com'],
+                'in_scope_rules': '*.example.com',
+                'out_of_scope_rules': ''
+            }
         ]
+        mock_get_h1_scopes.return_value = mock_programs
+
         pipeline = DataPipeline(config=self.mock_config)
-        seed_domain = "autonomous.com"
 
-        result_queue = pipeline.run_autonomous(seed_domain)
+        programs = pipeline.run_autonomous()
 
-        # Check that dynamic scope was generated and used
-        self.assertTrue(pipeline.scope_validator.is_in_scope("www.autonomous.com"))
-
-        # Check the final processed queue
-        result_list = list(result_queue)
-        self.assertEqual(len(result_list), 2)
-        self.assertIn(("www.autonomous.com", "domain"), result_list)
-        self.assertIn(("api.autonomous.com", "domain"), result_list)
+        mock_get_h1_scopes.assert_called_once_with('test_user', 'test_key')
+        self.assertEqual(len(programs), 1)
+        self.assertEqual(programs[0]['name'], 'test-program')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces a fully autonomous scanning mode to the application. This mode fetches bug bounty programs from the HackerOne API, validates their targets against their specific scopes, and initiates scans for each in-scope target.

Key changes:
- The `DataPipeline` is refactored to support fetching targets from HackerOne.
- The `main.py` entry point is updated to handle the autonomous workflow. The `--domain` flag is now optional and mutually exclusive with `--autonomous`.
- The main scanning logic is refactored into an `initiate_scan` function to be reusable for both single-target and autonomous scans.
- The `DataPipeline` is now instantiated with per-program scope rules during autonomous runs.
- Tests for the `DataPipeline` have been updated to reflect the new autonomous logic.
- A new `hackerone` section is added to the configuration file to store API credentials.