### PR TITLE
feat: Add automated scheduler and AI scan configuration

### DIFF
--- a/cyberhunter_3d/core/scheduler.py
+++ b/cyberhunter_3d/core/scheduler.py
@@ -1,0 +1,74 @@
+import logging
+from flask import Flask
+from .feeds.hackerone_client import get_hackerone_scopes
+from ..web.models import db, User, Scan, Target
+
+log = logging.getLogger(__name__)
+
+def sync_hackerone_programs(app: Flask):
+    """
+    Fetches HackerOne programs for all users with an API key and creates
+    new scans for programs that haven't been scanned before.
+    """
+    with app.app_context():
+        log.info("Scheduler: Starting HackerOne program sync job.")
+
+        # Get all users who have a HackerOne API key configured
+        users_with_h1_keys = User.query.filter(User.hackerone_api_key.isnot(None)).all()
+        if not users_with_h1_keys:
+            log.info("Scheduler: No users with HackerOne API keys found. Exiting job.")
+            return
+
+        total_new_scans = 0
+        for user in users_with_h1_keys:
+            log.info(f"Scheduler: Fetching programs for user '{user.username}'.")
+            # The H1 API requires both a username and a key for its auth
+            # Assuming the user's main username is their H1 username.
+            # A more robust implementation might store the H1 user separately.
+            try:
+                programs = get_hackerone_scopes(user.username, user.hackerone_api_key)
+            except Exception as e:
+                log.error(f"Scheduler: Failed to fetch H1 scopes for user '{user.username}': {e}")
+                continue
+
+            for program in programs:
+                program_name = program.get('name')
+                if not program_name:
+                    continue
+
+                # Create a unique source identifier for this program and user
+                scan_source_id = f"h1-{user.id}-{program_name}"
+
+                # Check if a scan from this source already exists
+                existing_scan = Scan.query.filter_by(source=scan_source_id, user_id=user.id).first()
+                if existing_scan:
+                    log.info(f"Scheduler: Scan for program '{program_name}' already exists for user '{user.username}'. Skipping.")
+                    continue
+
+                # If we are here, it's a new program, so create a scan
+                log.info(f"Scheduler: Found new program '{program_name}' for user '{user.username}'. Creating scan.")
+
+                # Create the new scan object
+                new_scan = Scan(
+                    user_id=user.id,
+                    status='QUEUED',
+                    scan_type='passive', # Automated scans default to passive
+                    source=scan_source_id,
+                    in_scope_rules=program.get('in_scope_rules', ''),
+                    out_of_scope_rules=program.get('out_of_scope_rules', '')
+                )
+                db.session.add(new_scan)
+
+                # We need to flush to get the new_scan.id
+                db.session.flush()
+
+                # Add all targets from the program to this scan
+                for target_value in program.get('targets', []):
+                    new_target = Target(value=target_value, scan_id=new_scan.id)
+                    db.session.add(new_target)
+
+                total_new_scans += 1
+
+        # Commit all the new scans and targets for all users at once
+        db.session.commit()
+        log.info(f"Scheduler: HackerOne sync job finished. Created {total_new_scans} new scans.")

--- a/cyberhunter_3d/web/models.py
+++ b/cyberhunter_3d/web/models.py
@@ -35,6 +35,8 @@ class Scan(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     # The profile for the scan, e.g., 'passive', 'full'
     scan_type = db.Column(db.String(50), nullable=False, default='passive')
+    # An identifier for the origin of the scan, e.g., 'h1-program-name'
+    source = db.Column(db.String(255), nullable=True, index=True)
     targets = db.relationship('Target', backref='scan', lazy=True, cascade="all, delete-orphan")
     results = db.Column(db.Text, nullable=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pdfkit
 lightgbm
 pandas
 scikit-learn
+APScheduler

--- a/run_web.py
+++ b/run_web.py
@@ -172,6 +172,9 @@ executor = ThreadPoolExecutor(max_workers=2)
 app.executor = executor
 
 from cyberhunter_3d.core.scan_manager import run_discovery_phase, run_url_discovery_phase
+from cyberhunter_3d.core.scheduler import sync_hackerone_programs
+from apscheduler.schedulers.background import BackgroundScheduler
+import atexit
 
 def run_full_scan(scan_id, app):
     """Runs both discovery and URL discovery phases."""
@@ -357,5 +360,19 @@ def scan_results(scan_id):
 # --- Main Execution ---
 if __name__ == '__main__':
     init_database(app.app_context())
+
+    # --- Scheduler Setup ---
+    # In a production environment, you might want a more robust scheduler setup,
+    # but for this self-contained app, a background scheduler is fine.
+    scheduler = BackgroundScheduler(daemon=True)
+    # Run the sync job every 24 hours
+    scheduler.add_job(sync_hackerone_programs, 'interval', hours=24, args=[app])
+    scheduler.start()
+    log.info("Scheduler started. HackerOne sync job scheduled to run every 24 hours.")
+
+    # Shut down the scheduler when exiting the app
+    atexit.register(lambda: scheduler.shutdown())
+
     # In a real deployment, use a proper WSGI server like Gunicorn.
-    app.run(debug=True, port=5001)
+    # The reloader can cause the scheduler to run twice, so disable it for production.
+    app.run(debug=True, port=5001, use_reloader=False)


### PR DESCRIPTION
This commit lays the groundwork for fully autonomous scanning by introducing an automated target feed and an AI-powered scan configuration system.

The Automated Target Feed & Scan Scheduler:
- Adds `APScheduler` as a dependency for background jobs.
- Implements a `sync_hackerone_programs` job in a new `scheduler.py` module. This job runs daily, fetches programs for all users with H1 keys, and creates 'passive' scans for new programs.
- Adds a `source` field to the `Scan` model to track scan origins and prevent duplicate automated scans.

The AI-Powered Scan Configuration:
- Implements an `AIScanConfigSelector` class to dynamically select scan plugins based on a profile.
- Adds a `scan_type` field to the `Scan` model.
- Updates the dashboard UI to allow users to select a 'Passive' or 'Full' scan profile.
- Integrates the selector into the core reconnaissance engine to use the user-defined or automated scan type.