### PR TITLE
feat: Implement live data integration for 3D monitoring view

### DIFF
--- a/cyberhunter_3d/core/scan_manager.py
+++ b/cyberhunter_3d/core/scan_manager.py
@@ -1,4 +1,4 @@
-from cyberhunter_3d.web.models import db, Scan, Target, Asset
+from cyberhunter_3d.web.models import db, Scan, Target, Asset, ScanProgress
 from cyberhunter_3d.core.reconnaissance.subdomain_enum import enumerate_subdomains_v2
 from cyberhunter_3d.core.reconnaissance.ip_scan import scan_ip_target
 from cyberhunter_3d.core.reconnaissance.asn_lookup import get_cidrs_for_asn
@@ -22,6 +22,16 @@ def run_url_discovery_phase(scan_id, app):
             # Assuming the main target for URL discovery is the 'domain' type
             if target.type == 'domain':
                 discover_urls(target.value, scan_id, app)
+
+def _update_progress(scan_id, module_name, progress):
+    """Helper to update the progress of a scan module."""
+    progress_entry = ScanProgress.query.filter_by(scan_id=scan_id, module_name=module_name).first()
+    if progress_entry:
+        progress_entry.progress = progress
+    else:
+        progress_entry = ScanProgress(scan_id=scan_id, module_name=module_name, progress=progress)
+        db.session.add(progress_entry)
+    db.session.commit()
 
 def _create_asset_if_new(scan_id, asset_type, value, validator, details=None):
     """Helper to create a new asset if it is in scope and doesn't already exist."""
@@ -54,6 +64,7 @@ def run_discovery_phase(scan_id, app):
         try:
             scan.status = 'RUNNING'
             db.session.commit()
+            _update_progress(scan_id, 'Discovery', 5)
             print(f"Scan {scan_id} discovery phase started.")
             validator = ScopeValidator(scan.in_scope_rules, scan.out_of_scope_rules)
 
@@ -80,7 +91,9 @@ def run_discovery_phase(scan_id, app):
 
                 elif target.type in ['domain', 'wildcard_domain']:
                     print(f"Finding subdomains for '{target.value}'...")
+                    _update_progress(scan_id, 'Subdomain Discovery', 20)
                     recon_data = enumerate_subdomains_v2(target.value)
+                    _update_progress(scan_id, 'Subdomain Discovery', 80)
 
                     # Persist assets directly from the recon data dictionary
                     for sub in recon_data.get('master_subdomains', []):
@@ -119,6 +132,7 @@ def run_discovery_phase(scan_id, app):
 
             scan.results = f"Discovery phase complete. Found {in_scope_count} new in-scope assets. Skipped {out_of_scope_count} out-of-scope items. Awaiting review to start intensive scan."
             scan.status = 'PENDING_REVIEW'
+            _update_progress(scan_id, 'Discovery', 100)
             print(f"Scan {scan_id} discovery phase complete.")
 
         except Exception as e:
@@ -145,23 +159,27 @@ def run_execution_phase(scan_id, app):
         try:
             scan.status = 'RUNNING'
             db.session.commit()
+            _update_progress(scan_id, 'Execution', 5)
             print(f"Scan {scan_id} execution phase started.")
             validator = ScopeValidator(scan.in_scope_rules, scan.out_of_scope_rules)
             out_of_scope_count = 0 # We need to track this across phases
 
             # 1. Port Scanning
+            _update_progress(scan_id, 'Network Scanning', 10)
             ip_targets = Asset.query.filter(
                 Asset.scan_id == scan.id,
                 Asset.is_approved_for_scan == True,
                 Asset.type.in_(['ip_address', 'cidr'])
             ).all()
-            for target in ip_targets:
+            for i, target in enumerate(ip_targets):
                 print(f"Port scanning '{target.value}'...")
                 ip_scan_assets = scan_ip_target(target.value)
                 for asset_data in ip_scan_assets:
                     if not Asset.query.filter_by(scan_id=scan.id, type=asset_data['type'], value=asset_data['value']).first():
                         db.session.add(Asset(type=asset_data['type'], value=asset_data['value'], details=asset_data.get('details'), scan_id=scan.id))
+                _update_progress(scan_id, 'Network Scanning', 10 + int(60 * (i + 1) / len(ip_targets)))
             db.session.commit()
+            _update_progress(scan_id, 'Network Scanning', 70)
 
             # 2. Expansion Phase (Reverse DNS)
             print("Starting Expansion: Reverse DNS")
@@ -206,6 +224,8 @@ def run_execution_phase(scan_id, app):
                 f"Skipped {out_of_scope_count} out-of-scope items during expansion."
             )
             scan.status = 'COMPLETED'
+            _update_progress(scan_id, 'Execution', 100)
+            _update_progress(scan_id, 'Network Scanning', 100)
             print(f"Scan {scan_id} execution phase complete.")
 
         except Exception as e:

--- a/cyberhunter_3d/web/api.py
+++ b/cyberhunter_3d/web/api.py
@@ -158,30 +158,47 @@ def get_scan_graph(scan_id):
 
     return jsonify({'graph_definition': graph_definition})
 
+from .models import ScanProgress, Finding
+
 @api_bp.route('/monitoring/status', methods=['GET'])
 def get_monitoring_status():
     """
-    Provides mock data for the 3D monitoring view.
-    In a real application, this would fetch real-time data from the scan manager.
+    Provides real-time data for the 3D monitoring view.
     """
-    mock_data = {
-        "scan_progress": [
-            {"name": "Subdomain Discovery", "progress": 65},
-            {"name": "URL Collection", "progress": 85},
-            {"name": "XSS Testing", "progress": 40},
-            {"name": "SQL Injection", "progress": 70},
-            {"name": "Network Scanning", "progress": 100}
-        ],
-        "vulnerability_feed": [
-            {"severity": "CRITICAL", "title": "XSS found in example.com/search"},
-            {"severity": "HIGH", "title": "SQL Injection in api.example.com/user"},
-            {"severity": "MEDIUM", "title": "CORS misconfiguration on *.example.com"},
-            {"severity": "LOW", "title": "Information disclosure /backup.sql"}
-        ],
-        "scanner_stats": {
-            "active": 127,
-            "queue": 1847,
-            "completed": 3492
-        }
+    # Scanner Stats
+    active_scans = Scan.query.filter_by(status='RUNNING').count()
+    queued_scans = Scan.query.filter_by(status='QUEUED').count()
+    completed_scans = Scan.query.filter_by(status='COMPLETED').count()
+
+    scanner_stats = {
+        "active": active_scans,
+        "queue": queued_scans,
+        "completed": completed_scans
     }
-    return jsonify(mock_data)
+
+    # Vulnerability Feed (most recent 5 findings)
+    vulnerability_feed = []
+    recent_findings = Finding.query.order_by(Finding.created_at.desc()).limit(5).all()
+    for finding in recent_findings:
+        vulnerability_feed.append({
+            "severity": finding.severity.upper(),
+            "title": finding.title
+        })
+
+    # Scan Progress (for the most recent running scan)
+    scan_progress = []
+    latest_running_scan = Scan.query.filter_by(status='RUNNING').order_by(Scan.created_at.desc()).first()
+    if latest_running_scan:
+        progress_entries = ScanProgress.query.filter_by(scan_id=latest_running_scan.id).all()
+        for entry in progress_entries:
+            scan_progress.append({
+                "name": entry.module_name,
+                "progress": entry.progress
+            })
+
+    data = {
+        "scan_progress": scan_progress,
+        "vulnerability_feed": vulnerability_feed,
+        "scanner_stats": scanner_stats
+    }
+    return jsonify(data)

--- a/cyberhunter_3d/web/models.py
+++ b/cyberhunter_3d/web/models.py
@@ -107,3 +107,18 @@ class Finding(db.Model):
 
     def __repr__(self):
         return f'<Finding {self.title} ({self.severity})>'
+
+class ScanProgress(db.Model):
+    """
+    Model to track the progress of individual modules within a scan.
+    """
+    id = db.Column(db.Integer, primary_key=True)
+    scan_id = db.Column(db.Integer, db.ForeignKey('scan.id'), nullable=False)
+    module_name = db.Column(db.String(100), nullable=False)
+    progress = db.Column(db.Integer, nullable=False, default=0)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    __table_args__ = (db.UniqueConstraint('scan_id', 'module_name', name='_scan_module_uc'),)
+
+    def __repr__(self):
+        return f'<ScanProgress {self.scan_id} - {self.module_name}: {self.progress}%>'


### PR DESCRIPTION
This commit replaces the mock data in the 3D monitoring view with live data from the scanning engine.

Key changes:
- Added a `ScanProgress` model to track the progress of individual scan modules.
- Modified the `scan_manager` to update the `ScanProgress` model during scans.
- Updated the `/api/v1/monitoring/status` endpoint to query the database for real-time scan progress, vulnerability findings, and scanner statistics.
- This makes the 3D monitoring view an autonomous, real-time dashboard.