### PR TITLE
Harden Reconnaissance Plugins with Resilience Features

### DIFF
--- a/cyberhunter_3d/common/exec.py
+++ b/cyberhunter_3d/common/exec.py
@@ -2,7 +2,7 @@ import subprocess
 from typing import List
 from .exceptions import ToolExecutionError
 
-def run_command(command: List[str]):
+def run_command(command: List[str], timeout: int = None):
     """
     Runs an external command and returns the output.
     Raises ToolExecutionError on failure.
@@ -13,9 +13,12 @@ def run_command(command: List[str]):
             capture_output=True,
             text=True,
             check=True,
+            timeout=timeout
         )
         return result.stdout
     except FileNotFoundError as e:
         raise ToolExecutionError(f"Command not found: {e.filename}") from e
+    except subprocess.TimeoutExpired as e:
+        raise ToolExecutionError(f"Command '{e.cmd}' timed out after {e.timeout} seconds.") from e
     except subprocess.CalledProcessError as e:
         raise ToolExecutionError(f"Command '{e.cmd}' returned non-zero exit status {e.returncode}.\nStderr: {e.stderr}") from e

--- a/cyberhunter_3d/common/schema.py
+++ b/cyberhunter_3d/common/schema.py
@@ -1,7 +1,13 @@
 from typing import TypedDict, List, Optional, Dict
 
 class Finding(TypedDict):
+    """
+    A structured dictionary to hold the results of a plugin's execution.
+    It can represent both successful findings and failures.
+    """
     tool: str
     phase: str
     target: str
-    evidence: Dict[str, str]
+    status: str  # 'success' or 'failed'
+    evidence: Optional[Dict[str, str]]
+    error: Optional[str]  # Description of the error if status is 'failed'

--- a/cyberhunter_3d/config/recon_config.yaml
+++ b/cyberhunter_3d/config/recon_config.yaml
@@ -39,3 +39,9 @@ screenshot_dir: recon_results/screenshots
 nmap_output_dir: recon_results/nmap
 final_recon_file: recon_results/final_recon_data.json
 master_subdomains_file: recon_results/master_subdomains.txt
+
+# Resilience settings for plugins
+resilience:
+  retries: 2
+  timeout_passive: 300  # 5 minutes
+  timeout_active: 600   # 10 minutes

--- a/cyberhunter_3d/core/reconnaissance/active_engine.py
+++ b/cyberhunter_3d/core/reconnaissance/active_engine.py
@@ -18,6 +18,10 @@ def run_active_enumeration(domain: str) -> Set[str]:
     logger.info(f"Starting active enumeration for: {domain}")
     all_subdomains: Set[str] = set()
 
+    # Load resilience and wordlist settings from config
+    resilience_config = config.get('resilience', {})
+    retries = resilience_config.get('retries', 1)
+    timeout = resilience_config.get('timeout_active', 600)
     wordlist = config['wordlists']['dns_bruteforce']
     resolvers = config['wordlists']['resolvers']
 
@@ -28,9 +32,9 @@ def run_active_enumeration(domain: str) -> Set[str]:
 
     # Create a dictionary mapping a plugin name to its instance and a zero-argument lambda runner
     plugin_runners = {
-        "gobuster": (gobuster_plugin, lambda: gobuster_plugin.run([domain], wordlist=wordlist)),
-        "puredns": (puredns_plugin, lambda: puredns_plugin.run([domain], wordlist=wordlist, resolvers=resolvers)),
-        "nmap_dns": (nmap_plugin, lambda: nmap_plugin.run([domain])),
+        "gobuster": (gobuster_plugin, lambda: gobuster_plugin.run([domain], wordlist=wordlist, retries=retries, timeout=timeout)),
+        "puredns": (puredns_plugin, lambda: puredns_plugin.run([domain], wordlist=wordlist, resolvers=resolvers, retries=retries, timeout=timeout)),
+        "nmap_dns": (nmap_plugin, lambda: nmap_plugin.run([domain], retries=retries, timeout=timeout)),
     }
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(plugin_runners)) as executor:
@@ -45,12 +49,19 @@ def run_active_enumeration(domain: str) -> Set[str]:
             name = future_to_plugin_name[future]
             try:
                 findings = future.result()
-                if findings:
-                    results = {f["evidence"]["poc"] for f in findings}
-                    all_subdomains.update(results)
-                    logger.info(f"Found {len(results)} subdomains with {name} plugin.")
+                successful_findings = 0
+                for finding in findings:
+                    if finding['status'] == 'success':
+                        all_subdomains.add(finding['evidence']['poc'])
+                        successful_findings += 1
+                    else:
+                        logger.error(f"Plugin {name} failed on target {finding['target']}: {finding['error']}")
+
+                if successful_findings > 0:
+                    logger.info(f"Found {successful_findings} subdomains with {name} plugin.")
+
             except Exception as exc:
-                logger.error(f"Plugin '{name}' generated an exception: {exc}", exc_info=True)
+                logger.exception(f"An unexpected error occurred with plugin {name}: {exc}")
 
     logger.info(f"Total unique active subdomains found: {len(all_subdomains)}")
     return all_subdomains

--- a/cyberhunter_3d/core/reconnaissance/passive_engine.py
+++ b/cyberhunter_3d/core/reconnaissance/passive_engine.py
@@ -3,10 +3,12 @@ import logging
 from typing import Set, List
 
 from .utils import get_logger
+from ...common.utils import load_config
 from ...plugins.recon.subfinder import SubfinderPlugin
 from ...plugins.recon.amass import AmassPlugin
 from ...plugins.recon.assetfinder import AssetfinderPlugin
 
+config = load_config()
 logger = get_logger(__name__)
 
 def run_passive_enumeration(domain: str) -> Set[str]:
@@ -17,6 +19,10 @@ def run_passive_enumeration(domain: str) -> Set[str]:
     logger.info(f"Starting passive enumeration for: {domain}")
     all_subdomains: Set[str] = set()
 
+    resilience_config = config.get('resilience', {})
+    retries = resilience_config.get('retries', 1)
+    timeout = resilience_config.get('timeout_passive', 300)
+
     plugins = [
         SubfinderPlugin(),
         AmassPlugin(),
@@ -24,20 +30,29 @@ def run_passive_enumeration(domain: str) -> Set[str]:
     ]
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(plugins)) as executor:
-        # Schedule each plugin to run
-        future_to_plugin = {executor.submit(plugin.run, [domain]): plugin for plugin in plugins}
+        # Schedule each plugin to run with resilience settings
+        future_to_plugin = {
+            executor.submit(plugin.run, [domain], retries=retries, timeout=timeout): plugin
+            for plugin in plugins
+        }
 
         for future in concurrent.futures.as_completed(future_to_plugin):
             plugin = future_to_plugin[future]
             try:
                 findings = future.result()
-                if findings:
-                    # Extract the subdomain from the 'poc' field in evidence
-                    results = {f["evidence"]["poc"] for f in findings}
-                    all_subdomains.update(results)
-                    logger.info(f"Found {len(results)} subdomains with {plugin.name()} plugin.")
+                successful_findings = 0
+                for finding in findings:
+                    if finding['status'] == 'success':
+                        all_subdomains.add(finding['evidence']['poc'])
+                        successful_findings += 1
+                    else:
+                        logger.error(f"Plugin {plugin.name()} failed on target {finding['target']}: {finding['error']}")
+
+                if successful_findings > 0:
+                    logger.info(f"Found {successful_findings} subdomains with {plugin.name()} plugin.")
+
             except Exception as e:
-                logger.exception(f"Plugin {plugin.name()} failed: {e}")
+                logger.exception(f"An unexpected error occurred with plugin {plugin.name()}: {e}")
 
     logger.info(f"Total discovered passive subdomains for {domain}: {len(all_subdomains)}")
     return all_subdomains

--- a/cyberhunter_3d/plugins/recon/amass.py
+++ b/cyberhunter_3d/plugins/recon/amass.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 from typing import List, Dict
 from ...common.exec import run_command
 from ...common.schema import Finding
@@ -14,22 +15,34 @@ class AmassPlugin:
     def check_dependencies(self) -> bool:
         return shutil.which(config['tools']['amass']) is not None
 
-    def run(self, targets: List[str]) -> List[Dict]:
+    def run(self, targets: List[str], retries: int = 1, timeout: int = 300) -> List[Dict]:
         if not self.check_dependencies():
-            print("Amass is not installed or configured.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "Amass tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                tool_path = config['tools']['amass']
-                command = [tool_path, "enum", "-passive", "-d", target, "-nolocal", "-nocolor"]
-                raw_output = run_command(command)
-                if raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                print(f"Error running amass: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['amass']
+                    command = [tool_path, "enum", "-passive", "-d", target, "-nolocal", "-nocolor"]
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break  # Success, exit retry loop
+                except ToolExecutionError as e:
+                    if attempt < retries - 1:
+                        time.sleep(2)
+                        continue
+                    else:
+                        all_findings.append({
+                            "tool": self.name(), "phase": self.phase(), "target": target,
+                            "status": "failed", "evidence": None, "error": str(e)
+                        })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
@@ -40,7 +53,9 @@ class AmassPlugin:
                     "target": target,
                     "phase": self.phase(),
                     "tool": self.name(),
+                    "status": "success",
                     "evidence": {"poc": subdomain.strip()},
+                    "error": None,
                 }
                 findings.append(finding)
         return findings

--- a/cyberhunter_3d/plugins/recon/assetfinder.py
+++ b/cyberhunter_3d/plugins/recon/assetfinder.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 from typing import List, Dict
 from ...common.exec import run_command
 from ...common.schema import Finding
@@ -14,34 +15,47 @@ class AssetfinderPlugin:
     def check_dependencies(self) -> bool:
         return shutil.which(config['tools']['assetfinder']) is not None
 
-    def run(self, targets: List[str]) -> List[Dict]:
+    def run(self, targets: List[str], retries: int = 1, timeout: int = 300) -> List[Dict]:
         if not self.check_dependencies():
-            print("Assetfinder is not installed or configured.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "Assetfinder tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                tool_path = config['tools']['assetfinder']
-                command = [tool_path, "--subs-only", target]
-                raw_output = run_command(command)
-                if raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                print(f"Error running assetfinder: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['assetfinder']
+                    command = [tool_path, "--subs-only", target]
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break  # Success, exit retry loop
+                except ToolExecutionError as e:
+                    if attempt < retries - 1:
+                        time.sleep(2)
+                        continue
+                    else:
+                        all_findings.append({
+                            "tool": self.name(), "phase": self.phase(), "target": target,
+                            "status": "failed", "evidence": None, "error": str(e)
+                        })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
         findings = []
-        # assetfinder can sometimes return duplicate or unrelated domains, filter them
         for subdomain in raw_output.strip().split('\n'):
             if subdomain and subdomain.endswith(target):
                 finding: Finding = {
                     "target": target,
                     "phase": self.phase(),
                     "tool": self.name(),
+                    "status": "success",
                     "evidence": {"poc": subdomain.strip()},
+                    "error": None,
                 }
                 findings.append(finding)
         return findings

--- a/cyberhunter_3d/plugins/recon/gobuster.py
+++ b/cyberhunter_3d/plugins/recon/gobuster.py
@@ -1,5 +1,6 @@
 import shutil
 import re
+import time
 from typing import List, Dict
 from ...common.exec import run_command
 from ...common.schema import Finding
@@ -15,34 +16,42 @@ class GobusterPlugin:
     def check_dependencies(self) -> bool:
         return shutil.which(config['tools']['gobuster']) is not None
 
-    def run(self, targets: List[str], wordlist: str) -> List[Dict]:
+    def run(self, targets: List[str], wordlist: str, retries: int = 1, timeout: int = 600) -> List[Dict]:
         if not self.check_dependencies():
-            print("Gobuster is not installed or configured.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "Gobuster tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                tool_path = config['tools']['gobuster']
-                command = [tool_path, 'dns', '-d', target, '-w', wordlist, '-q', '--no-color', '--no-error']
-                raw_output = run_command(command)
-                if raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                # Gobuster exits with status 1 if no domains are found.
-                # We can check stderr to be sure it's not a real error.
-                if "found no valid domain" in e.stderr.lower():
-                    print(f"Gobuster found no subdomains for {target}.")
-                else:
-                    print(f"Error running Gobuster: {e}")
-            except Exception as e:
-                print(f"A general error occurred with Gobuster plugin: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['gobuster']
+                    command = [tool_path, 'dns', '-d', target, '-w', wordlist, '-q', '--no-color', '--no-error']
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break # Success
+                except ToolExecutionError as e:
+                    # Gobuster can exit with non-zero status if no domains are found. This is not a true failure.
+                    if "found no valid domain" in e.stderr.lower():
+                        break # Not an error, just no results. Exit retry loop.
+
+                    if attempt < retries - 1:
+                        time.sleep(2)
+                        continue
+                    else:
+                        all_findings.append({
+                            "tool": self.name(), "phase": self.phase(), "target": target,
+                            "status": "failed", "evidence": None, "error": str(e)
+                        })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
         findings = []
-        # Gobuster output is like: "Found: blog.domain.com"
         pattern = re.compile(r'Found:\s*(.*)', re.IGNORECASE)
         for line in raw_output.strip().split('\n'):
             match = pattern.match(line.strip())
@@ -53,7 +62,9 @@ class GobusterPlugin:
                         "target": target,
                         "phase": self.phase(),
                         "tool": self.name(),
+                        "status": "success",
                         "evidence": {"poc": subdomain},
+                        "error": None,
                     }
                     findings.append(finding)
         return findings

--- a/cyberhunter_3d/plugins/recon/nmap_dns.py
+++ b/cyberhunter_3d/plugins/recon/nmap_dns.py
@@ -1,5 +1,6 @@
 import shutil
 import re
+import time
 from typing import List, Dict
 from ...common.exec import run_command
 from ...common.schema import Finding
@@ -15,32 +16,42 @@ class NmapDnsPlugin:
     def check_dependencies(self) -> bool:
         return shutil.which(config['tools']['nmap']) is not None
 
-    def run(self, targets: List[str]) -> List[Dict]:
+    def run(self, targets: List[str], retries: int = 1, timeout: int = 300) -> List[Dict]:
         if not self.check_dependencies():
-            print("Nmap is not installed or configured.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "Nmap tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                tool_path = config['tools']['nmap']
-                command = [tool_path, '--script', 'dns-zone-transfer', '-p', '53', target]
-                raw_output = run_command(command)
-                if raw_output and "dns-zone-transfer:" in raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                # Nmap can be noisy on stderr, only show error if zone transfer fails unexpectedly
-                if "failed to get zone" not in e.stderr.lower():
-                    print(f"Error running Nmap DNS Zone Transfer: {e}")
-            except Exception as e:
-                print(f"A general error occurred with Nmap DNS plugin: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['nmap']
+                    command = [tool_path, '--script', 'dns-zone-transfer', '-p', '53', target]
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output and "dns-zone-transfer:" in raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break  # Success
+                except ToolExecutionError as e:
+                    # A failed zone transfer is not necessarily a retryable error,
+                    # but we'll retry on timeouts or other execution issues.
+                    if attempt < retries - 1:
+                        time.sleep(2)
+                        continue
+                    else:
+                        # Only report as failure if it's not the common "failed to get zone" message
+                        if "failed to get zone" not in e.stderr.lower():
+                             all_findings.append({
+                                "tool": self.name(), "phase": self.phase(), "target": target,
+                                "status": "failed", "evidence": None, "error": str(e)
+                            })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
         findings = []
-        # Regex to capture the hostname from a line like:
-        # | an.example.com.              300 IN A     192.0.2.1
         pattern = re.compile(r'^\s*\|\s+([\w\-\.]+\.' + re.escape(target) + r')\.')
 
         for line in raw_output.strip().split('\n'):
@@ -51,7 +62,9 @@ class NmapDnsPlugin:
                     "target": target,
                     "phase": self.phase(),
                     "tool": self.name(),
+                    "status": "success",
                     "evidence": {"poc": subdomain},
+                    "error": None,
                 }
                 findings.append(finding)
         return findings

--- a/cyberhunter_3d/plugins/recon/puredns.py
+++ b/cyberhunter_3d/plugins/recon/puredns.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 from typing import List, Dict
 from ...common.exec import run_command
 from ...common.schema import Finding
@@ -14,28 +15,37 @@ class PureDNSPlugin:
     def check_dependencies(self) -> bool:
         return shutil.which(config['tools']['puredns']) is not None
 
-    def run(self, targets: List[str], wordlist: str, resolvers: str) -> List[Dict]:
+    def run(self, targets: List[str], wordlist: str, resolvers: str, retries: int = 1, timeout: int = 600) -> List[Dict]:
         if not self.check_dependencies():
-            print("PureDNS is not installed or configured.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "PureDNS tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                tool_path = config['tools']['puredns']
-                # puredns bruteforce [wordlist] [target] -r [resolvers] --output stdout --quiet
-                command = [
-                    tool_path, 'bruteforce', wordlist, target,
-                    '-r', resolvers, '--output', 'stdout', '--quiet'
-                ]
-                raw_output = run_command(command)
-                if raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                print(f"Error running PureDNS: {e}")
-            except Exception as e:
-                print(f"A general error occurred with PureDNS plugin: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['puredns']
+                    command = [
+                        tool_path, 'bruteforce', wordlist, target,
+                        '-r', resolvers, '--output', 'stdout', '--quiet'
+                    ]
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break  # Success
+                except ToolExecutionError as e:
+                    if attempt < retries - 1:
+                        time.sleep(2)
+                        continue
+                    else:
+                        all_findings.append({
+                            "tool": self.name(), "phase": self.phase(), "target": target,
+                            "status": "failed", "evidence": None, "error": str(e)
+                        })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
@@ -46,7 +56,9 @@ class PureDNSPlugin:
                     "target": target,
                     "phase": self.phase(),
                     "tool": self.name(),
+                    "status": "success",
                     "evidence": {"poc": subdomain.strip()},
+                    "error": None,
                 }
                 findings.append(finding)
         return findings

--- a/cyberhunter_3d/plugins/recon/subfinder.py
+++ b/cyberhunter_3d/plugins/recon/subfinder.py
@@ -1,31 +1,48 @@
 import shutil
+import time
 from typing import List, Dict
-from ...common.base_plugin import Plugin
 from ...common.exec import run_command
 from ...common.schema import Finding
 from ...common.exceptions import ToolExecutionError
-import datetime
+from ...common.utils import load_config
 
-class SubfinderPlugin(Plugin):
+config = load_config()
+
+class SubfinderPlugin:
     def name(self) -> str: return "subfinder"
     def phase(self) -> str: return "recon"
-    def check_dependencies(self) -> bool: return shutil.which("subfinder") is not None
 
-    def run(self, targets: List[str]) -> List[Dict]:
+    def check_dependencies(self) -> bool:
+        return shutil.which(config['tools']['subfinder']) is not None
+
+    def run(self, targets: List[str], retries: int = 1, timeout: int = 300) -> List[Dict]:
         if not self.check_dependencies():
-            print("Subfinder is not installed.")
-            return []
+            return [{
+                "tool": self.name(), "phase": self.phase(), "target": t,
+                "status": "failed", "evidence": None,
+                "error": "Subfinder tool not found."
+            } for t in targets]
 
         all_findings = []
         for target in targets:
-            try:
-                command = ["subfinder", "-d", target, "-silent"]
-                raw_output = run_command(command)
-                if raw_output:
-                    findings = self.parse(raw_output, target)
-                    all_findings.extend(findings)
-            except ToolExecutionError as e:
-                print(f"Error running subfinder: {e}")
+            for attempt in range(retries):
+                try:
+                    tool_path = config['tools']['subfinder']
+                    command = [tool_path, "-d", target, "-silent"]
+                    raw_output = run_command(command, timeout=timeout)
+                    if raw_output:
+                        findings = self.parse(raw_output, target)
+                        all_findings.extend(findings)
+                    break  # Success, exit retry loop
+                except ToolExecutionError as e:
+                    if attempt < retries - 1:
+                        time.sleep(2)  # Wait 2s before retrying
+                        continue
+                    else:
+                        all_findings.append({
+                            "tool": self.name(), "phase": self.phase(), "target": target,
+                            "status": "failed", "evidence": None, "error": str(e)
+                        })
         return all_findings
 
     def parse(self, raw_output: str, target: str) -> List[Dict]:
@@ -36,7 +53,9 @@ class SubfinderPlugin(Plugin):
                     "target": target,
                     "phase": self.phase(),
                     "tool": self.name(),
+                    "status": "success",
                     "evidence": {"poc": subdomain},
+                    "error": None,
                 }
                 findings.append(finding)
         return findings

--- a/cyberhunter_3d/tests/test_recon_v2.py
+++ b/cyberhunter_3d/tests/test_recon_v2.py
@@ -1,91 +1,83 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 from cyberhunter_3d.core.reconnaissance.passive_engine import run_passive_enumeration
 from cyberhunter_3d.core.reconnaissance.active_engine import run_active_enumeration
 
 # Mock Finding format that the plugins are expected to return
 def create_mock_finding(subdomain, tool, target="example.com"):
+    """Creates a mock for a successful finding."""
     return {
-        "target": target,
-        "phase": "recon",
-        "tool": tool,
-        "evidence": {"poc": subdomain},
+        "target": target, "phase": "recon", "tool": tool,
+        "status": "success", "evidence": {"poc": subdomain}, "error": None,
+    }
+
+def create_failed_finding(tool, error_msg, target="example.com"):
+    """Creates a mock for a failed finding."""
+    return {
+        "target": target, "phase": "recon", "tool": tool,
+        "status": "failed", "evidence": None, "error": error_msg,
     }
 
 @patch('cyberhunter_3d.core.reconnaissance.passive_engine.AssetfinderPlugin')
 @patch('cyberhunter_3d.core.reconnaissance.passive_engine.AmassPlugin')
 @patch('cyberhunter_3d.core.reconnaissance.passive_engine.SubfinderPlugin')
 def test_passive_engine_with_plugin_mocks(mock_subfinder, mock_amass, mock_assetfinder):
-    """
-    Tests the passive engine's orchestration of plugins.
-    We patch the plugins in the namespace of the module under test.
-    """
-    # Arrange: Configure mocks for each plugin's instance
-    # The .return_value represents the instance created by Plugin()
-    mock_subfinder.return_value.run.return_value = [
-        create_mock_finding("sub1.example.com", "subfinder"),
-        create_mock_finding("sub2.example.com", "subfinder"),
-    ]
-
-    mock_amass.return_value.run.return_value = [
-        create_mock_finding("sub2.example.com", "amass"), # Duplicate
-        create_mock_finding("sub3.example.com", "amass"),
-    ]
-
-    mock_assetfinder.return_value.run.return_value = [] # No findings
+    """Tests the passive engine's orchestration of plugins and resilience arg passing."""
+    # Arrange
+    mock_subfinder.return_value.run.return_value = [create_mock_finding("sub1.example.com", "subfinder")]
+    mock_amass.return_value.run.return_value = [create_mock_finding("sub2.example.com", "amass")]
+    mock_assetfinder.return_value.run.return_value = []
 
     # Act
     result_subdomains = run_passive_enumeration("example.com")
 
     # Assert
-    assert len(result_subdomains) == 3
-    assert result_subdomains == {"sub1.example.com", "sub2.example.com", "sub3.example.com"}
+    assert result_subdomains == {"sub1.example.com", "sub2.example.com"}
+    mock_subfinder.return_value.run.assert_called_once_with(["example.com"], retries=ANY, timeout=ANY)
+    mock_amass.return_value.run.assert_called_once_with(["example.com"], retries=ANY, timeout=ANY)
 
-    # Check that each plugin's run method was called once
-    mock_subfinder.return_value.run.assert_called_once_with(["example.com"])
-    mock_amass.return_value.run.assert_called_once_with(["example.com"])
-    mock_assetfinder.return_value.run.assert_called_once_with(["example.com"])
+@patch('cyberhunter_3d.core.reconnaissance.passive_engine.AssetfinderPlugin')
+@patch('cyberhunter_3d.core.reconnaissance.passive_engine.AmassPlugin')
+@patch('cyberhunter_3d.core.reconnaissance.passive_engine.SubfinderPlugin')
+def test_passive_engine_handles_plugin_failure(mock_subfinder, mock_amass, mock_assetfinder, caplog):
+    """Tests that the passive engine handles a structured failure from a plugin gracefully."""
+    # Arrange
+    mock_subfinder.return_value.name.return_value = "subfinder"
+    mock_subfinder.return_value.run.return_value = [create_mock_finding("good.example.com", "subfinder")]
 
+    mock_amass.return_value.name.return_value = "amass"
+    mock_amass.return_value.run.return_value = [create_failed_finding("amass", "Tool timed out")]
+
+    mock_assetfinder.return_value.name.return_value = "assetfinder"
+    mock_assetfinder.return_value.run.return_value = []
+
+    # Act
+    result_subdomains = run_passive_enumeration("example.com")
+
+    # Assert
+    assert result_subdomains == {"good.example.com"} # Only the successful finding should be included
+    assert "Plugin amass failed on target example.com: Tool timed out" in caplog.text
 
 @patch('cyberhunter_3d.core.reconnaissance.active_engine.NmapDnsPlugin')
 @patch('cyberhunter_3d.core.reconnaissance.active_engine.PureDNSPlugin')
 @patch('cyberhunter_3d.core.reconnaissance.active_engine.GobusterPlugin')
 def test_active_engine_with_plugin_mocks(mock_gobuster, mock_puredns, mock_nmap):
-    """
-    Tests the active engine's orchestration of plugins.
-    We patch the plugins in the namespace of the module under test.
-    """
+    """Tests the active engine's orchestration and resilience arg passing."""
     # Arrange
-    # Mock gobuster
-    mock_gobuster.return_value.name.return_value = "gobuster"
     mock_gobuster.return_value.check_dependencies.return_value = True
-    mock_gobuster.return_value.run.return_value = [
-        create_mock_finding("active1.example.com", "gobuster")
-    ]
+    mock_gobuster.return_value.run.return_value = [create_mock_finding("active1.example.com", "gobuster")]
 
-    # Mock puredns
-    mock_puredns.return_value.name.return_value = "puredns"
     mock_puredns.return_value.check_dependencies.return_value = True
-    mock_puredns.return_value.run.return_value = [
-        create_mock_finding("active2.example.com", "puredns")
-    ]
+    mock_puredns.return_value.run.return_value = [create_mock_finding("active2.example.com", "puredns")]
 
-    # Mock nmap
-    mock_nmap.return_value.name.return_value = "nmap_dns"
     mock_nmap.return_value.check_dependencies.return_value = True
-    mock_nmap.return_value.run.return_value = [
-        create_mock_finding("active1.example.com", "nmap_dns"), # Duplicate
-        create_mock_finding("active3.example.com", "nmap_dns"),
-    ]
+    mock_nmap.return_value.run.return_value = []
 
     # Act
     result_subdomains = run_active_enumeration("example.com")
 
     # Assert
-    assert len(result_subdomains) == 3
-    assert result_subdomains == {"active1.example.com", "active2.example.com", "active3.example.com"}
-
-    # Check that run methods were called correctly
-    mock_gobuster.return_value.run.assert_called_once()
-    mock_puredns.return_value.run.assert_called_once()
-    mock_nmap.return_value.run.assert_called_once()
+    assert result_subdomains == {"active1.example.com", "active2.example.com"}
+    mock_gobuster.return_value.run.assert_called_once_with([ANY], wordlist=ANY, retries=ANY, timeout=ANY)
+    mock_puredns.return_value.run.assert_called_once_with([ANY], wordlist=ANY, resolvers=ANY, retries=ANY, timeout=ANY)
+    mock_nmap.return_value.run.assert_called_once_with([ANY], retries=ANY, timeout=ANY)


### PR DESCRIPTION
This commit builds upon the previous plugin refactoring by adding key resilience features to the reconnaissance engines and plugins.

The following changes were implemented:
- **Timeout Support**: The central `run_command` utility now accepts a `timeout` parameter, preventing any single tool from stalling the entire pipeline.
- **Retry Mechanism**: All reconnaissance plugins now implement a retry loop, making them more robust against transient network errors or flaky tools.
- **Structured Error Reporting**: The `Finding` schema was updated to include `status` and `error` fields. Plugins no longer raise exceptions on failure; instead, they catch them and return a structured `Finding` object with `status: 'failed'`.
- **Engine Updates**: The `passive_engine` and `active_engine` were updated to read resilience settings (timeouts, retries) from the config and pass them to the plugins. They now also inspect the status of each finding, logging failures gracefully while continuing execution.
- **Updated Tests**: The test suite was enhanced to verify the new resilience features, including correct parameter passing and the engine's ability to handle structured plugin failures.