### PR TITLE
Refactor Passive and Active Engines to a Plugin Architecture

### DIFF
--- a/cyberhunter_3d/core/reconnaissance/active_engine.py
+++ b/cyberhunter_3d/core/reconnaissance/active_engine.py
@@ -1,41 +1,56 @@
-import subprocess
-import tempfile
-import os
-import re
 import concurrent.futures
+import logging
 from typing import Set, List
 
-from .utils import load_config, get_logger, run_command
+from .utils import get_logger
+from ...common.utils import load_config
+from ...plugins.recon.gobuster import GobusterPlugin
+from ...plugins.recon.puredns import PureDNSPlugin
+from ...plugins.recon.nmap_dns import NmapDnsPlugin
 
 config = load_config()
 logger = get_logger(__name__)
 
 def run_active_enumeration(domain: str) -> Set[str]:
     """
-    Runs active subdomain enumeration tools in parallel.
+    Runs active subdomain enumeration tools in parallel using plugins.
     """
     logger.info(f"Starting active enumeration for: {domain}")
+    all_subdomains: Set[str] = set()
 
     wordlist = config['wordlists']['dns_bruteforce']
     resolvers = config['wordlists']['resolvers']
 
-    commands = [
-        [config['tools']['gobuster'], 'dns', '-d', '{domain}', '-w', wordlist, '-o', '{output_file}', '-q'],
-        [config['tools']['puredns'], 'bruteforce', wordlist, '{domain}', '-r', resolvers, '-w', '{output_file}'],
-        [config['tools']['nmap'], '--script', 'dns-zone-transfer', '-p', '53', '{domain}', '-oN', '{output_file}']
-    ]
+    # Instantiate plugins
+    gobuster_plugin = GobusterPlugin()
+    puredns_plugin = PureDNSPlugin()
+    nmap_plugin = NmapDnsPlugin()
 
-    all_subdomains = set()
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(commands)) as executor:
-        future_to_command = {executor.submit(run_command, cmd, domain, wordlist): cmd for cmd in commands}
-        for future in concurrent.futures.as_completed(future_to_command):
-            command = future_to_command[future]
+    # Create a dictionary mapping a plugin name to its instance and a zero-argument lambda runner
+    plugin_runners = {
+        "gobuster": (gobuster_plugin, lambda: gobuster_plugin.run([domain], wordlist=wordlist)),
+        "puredns": (puredns_plugin, lambda: puredns_plugin.run([domain], wordlist=wordlist, resolvers=resolvers)),
+        "nmap_dns": (nmap_plugin, lambda: nmap_plugin.run([domain])),
+    }
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(plugin_runners)) as executor:
+        # Filter plugins by dependencies and submit their runners to the executor
+        future_to_plugin_name = {
+            executor.submit(runner): name
+            for name, (plugin, runner) in plugin_runners.items()
+            if plugin.check_dependencies()
+        }
+
+        for future in concurrent.futures.as_completed(future_to_plugin_name):
+            name = future_to_plugin_name[future]
             try:
-                subdomains = future.result()
-                logger.info(f"Found {len(subdomains)} subdomains with {' '.join(command)}")
-                all_subdomains.update(subdomains)
+                findings = future.result()
+                if findings:
+                    results = {f["evidence"]["poc"] for f in findings}
+                    all_subdomains.update(results)
+                    logger.info(f"Found {len(results)} subdomains with {name} plugin.")
             except Exception as exc:
-                logger.error(f"'{' '.join(command)}' generated an exception: {exc}")
+                logger.error(f"Plugin '{name}' generated an exception: {exc}", exc_info=True)
 
     logger.info(f"Total unique active subdomains found: {len(all_subdomains)}")
     return all_subdomains

--- a/cyberhunter_3d/plugins/recon/gobuster.py
+++ b/cyberhunter_3d/plugins/recon/gobuster.py
@@ -1,0 +1,57 @@
+import shutil
+import re
+from typing import List, Dict
+from ...common.exec import run_command
+from ...common.schema import Finding
+from ...common.exceptions import ToolExecutionError
+from ...common.utils import load_config
+
+config = load_config()
+
+class GobusterPlugin:
+    def name(self) -> str: return "gobuster"
+    def phase(self) -> str: return "recon-active"
+
+    def check_dependencies(self) -> bool:
+        return shutil.which(config['tools']['gobuster']) is not None
+
+    def run(self, targets: List[str], wordlist: str) -> List[Dict]:
+        if not self.check_dependencies():
+            print("Gobuster is not installed or configured.")
+            return []
+
+        all_findings = []
+        for target in targets:
+            try:
+                tool_path = config['tools']['gobuster']
+                # We remove the -o flag to capture stdout
+                command = [tool_path, 'dns', '-d', target, '-w', wordlist, '-q', '--no-color', '--no-error']
+                raw_output = run_command(command)
+                if raw_output:
+                    findings = self.parse(raw_output, target)
+                    all_findings.extend(findings)
+            except ToolExecutionError as e:
+                # Gobuster exits with status 1 if no domains are found, which is not a true error.
+                if "found no valid domain" not in e.stderr.lower():
+                    print(f"Error running Gobuster: {e}")
+            except Exception as e:
+                print(f"A general error occurred with Gobuster plugin: {e}")
+        return all_findings
+
+    def parse(self, raw_output: str, target: str) -> List[Dict]:
+        findings = []
+        # Gobuster's output format is typically "Found: subdomain.domain.com"
+        pattern = re.compile(r'Found:\s*(.*)', re.IGNORECASE)
+        for line in raw_output.strip().split('\n'):
+            match = pattern.match(line.strip())
+            if match:
+                subdomain = match.group(1).strip()
+                if subdomain.endswith(target):
+                    finding: Finding = {
+                        "target": target,
+                        "phase": self.phase(),
+                        "tool": self.name(),
+                        "evidence": {"poc": subdomain},
+                    }
+                    findings.append(finding)
+        return findings

--- a/cyberhunter_3d/plugins/recon/nmap_dns.py
+++ b/cyberhunter_3d/plugins/recon/nmap_dns.py
@@ -1,0 +1,57 @@
+import shutil
+import re
+from typing import List, Dict
+from ...common.exec import run_command
+from ...common.schema import Finding
+from ...common.exceptions import ToolExecutionError
+from ...common.utils import load_config
+
+config = load_config()
+
+class NmapDnsPlugin:
+    def name(self) -> str: return "nmap-dns-xfer"
+    def phase(self) -> str: return "recon-active"
+
+    def check_dependencies(self) -> bool:
+        return shutil.which(config['tools']['nmap']) is not None
+
+    def run(self, targets: List[str]) -> List[Dict]:
+        if not self.check_dependencies():
+            print("Nmap is not installed or configured.")
+            return []
+
+        all_findings = []
+        for target in targets:
+            try:
+                tool_path = config['tools']['nmap']
+                command = [tool_path, '--script', 'dns-zone-transfer', '-p', '53', target]
+                raw_output = run_command(command)
+                if raw_output and "dns-zone-transfer:" in raw_output:
+                    findings = self.parse(raw_output, target)
+                    all_findings.extend(findings)
+            except ToolExecutionError as e:
+                # Nmap can be noisy on stderr, only show error if zone transfer fails unexpectedly
+                if "failed to get zone" not in e.stderr.lower():
+                    print(f"Error running Nmap DNS Zone Transfer: {e}")
+            except Exception as e:
+                print(f"A general error occurred with Nmap DNS plugin: {e}")
+        return all_findings
+
+    def parse(self, raw_output: str, target: str) -> List[Dict]:
+        findings = []
+        # Regex to capture the hostname from a line like:
+        # | an.example.com.              300 IN A     192.0.2.1
+        pattern = re.compile(r'^\s*\|\s+([\w\-\.]+\.' + re.escape(target) + r')\.')
+
+        for line in raw_output.strip().split('\n'):
+            match = pattern.match(line)
+            if match:
+                subdomain = match.group(1).strip()
+                finding: Finding = {
+                    "target": target,
+                    "phase": self.phase(),
+                    "tool": self.name(),
+                    "evidence": {"poc": subdomain},
+                }
+                findings.append(finding)
+        return findings

--- a/cyberhunter_3d/plugins/recon/puredns.py
+++ b/cyberhunter_3d/plugins/recon/puredns.py
@@ -1,0 +1,50 @@
+import shutil
+from typing import List, Dict
+from ...common.exec import run_command
+from ...common.schema import Finding
+from ...common.exceptions import ToolExecutionError
+from ...common.utils import load_config
+
+config = load_config()
+
+class PureDNSPlugin:
+    def name(self) -> str: return "puredns"
+    def phase(self) -> str: return "recon-active"
+
+    def check_dependencies(self) -> bool:
+        return shutil.which(config['tools']['puredns']) is not None
+
+    def run(self, targets: List[str], wordlist: str, resolvers: str) -> List[Dict]:
+        if not self.check_dependencies():
+            print("PureDNS is not installed or configured.")
+            return []
+
+        all_findings = []
+        for target in targets:
+            try:
+                tool_path = config['tools']['puredns']
+                # puredns bruteforce [wordlist] [target] -r [resolvers] --output stdout --quiet
+                command = [
+                    tool_path, 'bruteforce', wordlist, target,
+                    '-r', resolvers, '--output', 'stdout', '--quiet'
+                ]
+                raw_output = run_command(command)
+                if raw_output:
+                    findings = self.parse(raw_output, target)
+                    all_findings.extend(findings)
+            except ToolExecutionError as e:
+                print(f"Error running PureDNS: {e}")
+        return all_findings
+
+    def parse(self, raw_output: str, target: str) -> List[Finding]:
+        findings = []
+        for subdomain in raw_output.strip().split('\n'):
+            if subdomain and target in subdomain:
+                finding: Finding = {
+                    "target": target,
+                    "phase": self.phase(),
+                    "tool": self.name(),
+                    "evidence": {"poc": subdomain.strip()},
+                }
+                findings.append(finding)
+        return findings

--- a/cyberhunter_3d/tests/test_recon_v2.py
+++ b/cyberhunter_3d/tests/test_recon_v2.py
@@ -48,3 +48,45 @@ def test_passive_engine_with_plugin_mocks(mock_subfinder, mock_amass, mock_asset
     mock_subfinder.return_value.run.assert_called_once_with(["example.com"])
     mock_amass.return_value.run.assert_called_once_with(["example.com"])
     mock_assetfinder.return_value.run.assert_called_once_with(["example.com"])
+
+
+from cyberhunter_3d.core.reconnaissance.active_engine import run_active_enumeration
+
+@patch('cyberhunter_3d.core.reconnaissance.active_engine.NmapDnsPlugin')
+@patch('cyberhunter_3d.core.reconnaissance.active_engine.PureDNSPlugin')
+@patch('cyberhunter_3d.core.reconnaissance.active_engine.GobusterPlugin')
+def test_active_engine_with_plugin_mocks(mock_gobuster, mock_puredns, mock_nmap):
+    """
+    Tests the active engine's orchestration of plugins.
+    """
+    # Arrange
+    mock_gobuster.return_value.name.return_value = "gobuster"
+    mock_gobuster.return_value.check_dependencies.return_value = True
+    mock_gobuster.return_value.run.return_value = [
+        create_mock_finding("active1.example.com", "gobuster")
+    ]
+
+    mock_puredns.return_value.name.return_value = "puredns"
+    mock_puredns.return_value.check_dependencies.return_value = True
+    mock_puredns.return_value.run.return_value = [
+        create_mock_finding("active2.example.com", "puredns")
+    ]
+
+    mock_nmap.return_value.name.return_value = "nmap_dns"
+    mock_nmap.return_value.check_dependencies.return_value = True
+    mock_nmap.return_value.run.return_value = [
+        create_mock_finding("active1.example.com", "nmap_dns"), # Duplicate
+        create_mock_finding("active3.example.com", "nmap_dns"),
+    ]
+
+    # Act
+    result_subdomains = run_active_enumeration("example.com")
+
+    # Assert
+    assert len(result_subdomains) == 3
+    assert result_subdomains == {"active1.example.com", "active2.example.com", "active3.example.com"}
+
+    # Check that run methods were called correctly
+    mock_gobuster.return_value.run.assert_called_once()
+    mock_puredns.return_value.run.assert_called_once()
+    mock_nmap.return_value.run.assert_called_once()


### PR DESCRIPTION
This commit completes the refactoring of `passive_engine.py` and `active_engine.py` to be fully plugin-based.

The direct-execution logic for all tools (`amass`, `assetfinder`, `gobuster`, `puredns`, `nmap`) has been removed from the engines. This functionality is now encapsulated in new, self-contained plugins.

The engine modules are now clean orchestrators that run their respective plugins in parallel.

Additionally, the `load_config` function has been moved to a new `common/utils.py` file to provide a centralized, easily accessible utility for all modules.

The test suite has been updated with robust unit tests that mock the plugin layer and verify the correct orchestration and result aggregation by both engines.