### PR TITLE
Update .gitignore with a comprehensive set of rules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,144 @@ subdomains_dead.txt
 *.bak
 *.orig
 *.rej
+
+# ---- Python bytecode ----
+__pycache__/
+*.py[cod]
+*$py.class
+
+# ---- C extensions ----
+*.so
+
+# ---- Distribution / packaging ----
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+pip-wheel-metadata/
+.installed.cfg
+*.egg-info/
+*.egg
+MANIFEST
+
+# ---- PyInstaller ----
+*.manifest
+*.spec
+
+# ---- Installer logs ----
+pip-log.txt
+pip-delete-this-directory.txt
+
+# ---- Unit test / coverage reports ----
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# ---- Translations ----
+*.mo
+*.pot
+
+# ---- Django stuff ----
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# ---- Flask stuff ----
+instance/
+.webassets-cache
+
+# ---- Scrapy stuff ----
+.scrapy
+
+# ---- Sphinx documentation ----
+docs/_build/
+
+# ---- PyBuilder ----
+target/
+
+# ---- Jupyter Notebook ----
+.ipynb_checkpoints
+
+# ---- IPython ----
+profile_default/
+ipython_config.py
+
+# ---- pyenv ----
+.python-version
+
+# ---- PEP 582; used by poetry and pdm ----
+__pypackages__/
+
+# ---- Celery stuff ----
+celerybeat-schedule
+celerybeat.pid
+
+# ---- SageMath parsed files ----
+*.sage.py
+
+# ---- Environments ----
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# ---- IDE / Editor settings ----
+.spyderproject
+.spyproject
+.ropeproject
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+# ---- mkdocs documentation ----
+/site
+
+# ---- mypy ----
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# ---- Pyre type checker ----
+.pyre/
+
+# ---- pytype static analyzer ----
+.pytype/
+
+# ---- Cython debug symbols ----
+cython_debug/
+
+# ---- Logs & Databases ----
+*.db
+*.sqlite
+*.sqlite3
+*.log
+
+# ---- CyberHunter 3D specific ----
+cyberhunter.db
+subdomains_alive.txt
+subdomains_dead.txt
+*.log


### PR DESCRIPTION
Appends a user-provided list of common Python, IDE, and project-specific files and directories to the .gitignore file. This will help prevent tracking of temporary files, build artifacts, and environment-specific files, and should help to avoid future merge conflicts related to ignored files.