### PR TITLE
refactor: Refactor API tests to use pytest

### DIFF
--- a/cyberhunter_3d/tests/test_api.py
+++ b/cyberhunter_3d/tests/test_api.py
@@ -1,123 +1,132 @@
-import unittest
+import pytest
 import json
-from unittest.mock import patch, MagicMock
-from run_web import app, db
+from unittest.mock import MagicMock
+from run_web import app as main_app, db as main_db
 from cyberhunter_3d.web.models import User, Scan, Target, Asset
 
-class APITestCase(unittest.TestCase):
-    def setUp(self):
-        """Set up a test client and a test database."""
-        app.config['TESTING'] = True
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-        self.client = app.test_client()
-        with app.app_context():
-            db.create_all()
+@pytest.fixture
+def client_with_user():
+    """A pytest fixture to set up the test client, database, and a test user."""
+    main_app.config['TESTING'] = True
+    main_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+
+    # Attach a mock executor to the app for testing
+    mock_executor = MagicMock()
+    main_app.executor = mock_executor
+
+    with main_app.test_client() as client:
+        with main_app.app_context():
+            main_db.create_all()
             # Create a test user
-            self.test_user = User(username='testuser', password_hash='somehash', otp_secret='secret')
-            db.session.add(self.test_user)
-            db.session.commit()
-            self.api_key = self.test_user.api_key
+            test_user = User(username='testuser', password_hash='somehash', otp_secret='secret')
+            main_db.session.add(test_user)
+            main_db.session.commit()
+            user_id = test_user.id
+        yield client, user_id, mock_executor
 
-    def tearDown(self):
-        """Clean up the database after each test."""
-        with app.app_context():
-            db.session.remove()
-            db.drop_all()
+    with main_app.app_context():
+        main_db.drop_all()
 
-    def test_ping_unauthorized(self):
-        """Test that ping endpoint requires an API key."""
-        response = self.client.get('/api/v1/ping')
-        self.assertEqual(response.status_code, 401)
+def test_ping_unauthorized(client_with_user):
+    """Test that ping endpoint requires an API key."""
+    test_client, _, _ = client_with_user
+    response = test_client.get('/api/v1/ping')
+    assert response.status_code == 401
 
-    def test_ping_authorized(self):
-        """Test that ping endpoint works with a valid API key."""
-        response = self.client.get('/api/v1/ping', headers={'X-API-Key': self.api_key})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.data)['message'], 'pong')
+def test_ping_authorized(client_with_user):
+    """Test that ping endpoint works with a valid API key."""
+    test_client, user_id, _ = client_with_user
+    with main_app.app_context():
+        test_user = main_db.session.get(User, user_id)
+        response = test_client.get('/api/v1/ping', headers={'X-API-Key': test_user.api_key})
+        assert response.status_code == 200
+        assert json.loads(response.data)['message'] == 'pong'
 
-    @patch('cyberhunter_3d.web.api.get_executor')
-    def test_create_scan_api(self, mock_get_executor):
-        """Test creating a scan via the API."""
-        # Mock the executor to avoid running background tasks
-        mock_executor = MagicMock()
-        mock_get_executor.return_value = mock_executor
+def test_create_scan_api(client_with_user):
+    """Test creating a scan via the API."""
+    test_client, user_id, mock_executor = client_with_user
 
+    with main_app.app_context():
+        test_user = main_db.session.get(User, user_id)
         payload = {
             "targets": ["example.com", "1.1.1.1"],
             "in_scope_rules": "*.example.com"
         }
-        response = self.client.post('/api/v1/scans',
-                                    headers={'X-API-Key': self.api_key},
+        response = test_client.post('/api/v1/scans',
+                                    headers={'X-API-Key': test_user.api_key},
                                     data=json.dumps(payload),
                                     content_type='application/json')
 
-        self.assertEqual(response.status_code, 202)
-        response_data = json.loads(response.data)
-        self.assertIn('scan_id', response_data)
-        scan_id = response_data['scan_id']
+    assert response.status_code == 202
+    response_data = json.loads(response.data)
+    assert 'scan_id' in response_data
+    scan_id = response_data['scan_id']
 
-        # Verify the scan was created in the DB within an app context
-        with app.app_context():
-            scan = db.session.get(Scan, scan_id)
-            self.assertIsNotNone(scan)
-            self.assertEqual(scan.user_id, self.test_user.id)
+    # Verify the scan was created in the DB within an app context
+    with main_app.app_context():
+        scan = main_db.session.get(Scan, scan_id)
+        assert scan is not None
+        assert scan.user_id == user_id
 
-        # Verify that the background task was called
-        mock_executor.submit.assert_called_once()
+    # Verify that the background task was called
+    mock_executor.submit.assert_called_once()
 
-    def test_get_scan_status_api(self):
-        """Test getting scan status via the API."""
-        with app.app_context():
-            # First, create a scan to check
-            scan = Scan(user_id=self.test_user.id, status='COMPLETED', results='Test summary')
-            db.session.add(scan)
-            db.session.commit()
-            scan_id = scan.id
+def test_get_scan_status_api(client_with_user):
+    """Test getting scan status via the API."""
+    test_client, user_id, _ = client_with_user
+    with main_app.app_context():
+        test_user = main_db.session.get(User, user_id)
+        # First, create a scan to check
+        scan = Scan(user_id=user_id, status='COMPLETED', results='Test summary')
+        main_db.session.add(scan)
+        main_db.session.commit()
+        scan_id = scan.id
 
-        response = self.client.get(f'/api/v1/scans/{scan_id}/status', headers={'X-API-Key': self.api_key})
-        self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
-        self.assertEqual(response_data['status'], 'COMPLETED')
-        self.assertEqual(response_data['summary'], 'Test summary')
+        response = test_client.get(f'/api/v1/scans/{scan_id}/status', headers={'X-API-Key': test_user.api_key})
+    assert response.status_code == 200
+    response_data = json.loads(response.data)
+    assert response_data['status'] == 'COMPLETED'
+    assert response_data['summary'] == 'Test summary'
 
-    def test_get_scan_results_api(self):
-        """Test getting scan results via the API."""
-        with app.app_context():
-            # Create a scan and some assets
-            scan = Scan(user_id=self.test_user.id, status='COMPLETED')
-            db.session.add(scan)
-            db.session.flush()
-            asset1 = Asset(scan_id=scan.id, type='subdomain', value='test.example.com')
-            asset2 = Asset(scan_id=scan.id, type='ip_address', value='1.2.3.4')
-            db.session.add_all([asset1, asset2])
-            db.session.commit()
-            scan_id = scan.id
+def test_get_scan_results_api(client_with_user):
+    """Test getting scan results via the API."""
+    test_client, user_id, _ = client_with_user
+    with main_app.app_context():
+        test_user = main_db.session.get(User, user_id)
+        # Create a scan and some assets
+        scan = Scan(user_id=user_id, status='COMPLETED')
+        main_db.session.add(scan)
+        main_db.session.flush()
+        asset1 = Asset(scan_id=scan.id, type='subdomain', value='test.example.com')
+        asset2 = Asset(scan_id=scan.id, type='ip_address', value='1.2.3.4')
+        main_db.session.add_all([asset1, asset2])
+        main_db.session.commit()
+        scan_id = scan.id
 
-        response = self.client.get(f'/api/v1/scans/{scan_id}/results', headers={'X-API-Key': self.api_key})
-        self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
-        self.assertEqual(len(response_data['assets']), 2)
-        self.assertEqual(response_data['assets'][0]['value'], 'test.example.com')
+        response = test_client.get(f'/api/v1/scans/{scan_id}/results', headers={'X-API-Key': test_user.api_key})
+    assert response.status_code == 200
+    response_data = json.loads(response.data)
+    assert len(response_data['assets']) == 2
+    assert response_data['assets'][0]['value'] == 'test.example.com'
 
-    def test_get_scan_graph_api(self):
-        """Test getting scan graph data via the API."""
-        with app.app_context():
-            scan = Scan(user_id=self.test_user.id, status='COMPLETED')
-            db.session.add(scan)
-            db.session.flush()
-            t1 = Target(scan_id=scan.id, type='domain', value='example.com')
-            a1 = Asset(scan_id=scan.id, type='subdomain', value='test.example.com')
-            db.session.add_all([t1, a1])
-            db.session.commit()
-            scan_id = scan.id
+def test_get_scan_graph_api(client_with_user):
+    """Test getting scan graph data via the API."""
+    test_client, user_id, _ = client_with_user
+    with main_app.app_context():
+        test_user = main_db.session.get(User, user_id)
+        scan = Scan(user_id=user_id, status='COMPLETED')
+        main_db.session.add(scan)
+        main_db.session.flush()
+        t1 = Target(scan_id=scan.id, type='domain', value='example.com')
+        a1 = Asset(scan_id=scan.id, type='subdomain', value='test.example.com')
+        main_db.session.add_all([t1, a1])
+        main_db.session.commit()
+        scan_id = scan.id
 
-        response = self.client.get(f'/api/v1/scans/{scan_id}/graph', headers={'X-API-Key': self.api_key})
-        self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.data)
-        self.assertIn('graph_definition', response_data)
-        self.assertIn('graph TD', response_data['graph_definition'])
-        self.assertIn('target1("example.com (domain)")', response_data['graph_definition'])
-        self.assertIn('asset1testexamplecom("test.example.com (subdomain)")', response_data['graph_definition'])
-
-if __name__ == '__main__':
-    unittest.main()
+        response = test_client.get(f'/api/v1/scans/{scan_id}/graph', headers={'X-API-Key': test_user.api_key})
+    assert response.status_code == 200
+    response_data = json.loads(response.data)
+    assert 'graph_definition' in response_data
+    assert 'graph TD' in response_data['graph_definition']
+    assert 'target1("example.com (domain)")' in response_data['graph_definition']
+    assert 'asset1testexamplecom("test.example.com (subdomain)")' in response_data['graph_definition']


### PR DESCRIPTION
This commit refactors the `test_api.py` file to use `pytest` style tests instead of `unittest`.

- Replaced the `unittest.TestCase` class with `pytest` test functions.
- Replaced the `setUp` and `tearDown` methods with a `pytest` fixture that yields a test client and a test user.
- This makes the test suite more consistent and maintainable.